### PR TITLE
fix: normalize weight_body_mass to canonical weight metric

### DIFF
--- a/app/services/metrics_parser.rb
+++ b/app/services/metrics_parser.rb
@@ -7,6 +7,11 @@ class MetricsParser
     environmental_audio_exposure headphone_audio_exposure
   ].freeze
 
+  # Health Auto Export sends metric names that differ from our canonical names
+  NAME_MAP = {
+    "weight_body_mass" => "weight"
+  }.freeze
+
   KJ_TO_KCAL_METRICS = %w[active_energy basal_energy_burned].freeze
   KJ_TO_KCAL = 4.184
 
@@ -24,7 +29,8 @@ class MetricsParser
     skipped = 0
 
     @metrics_data.each do |metric_entry|
-      name = metric_entry["name"]
+      raw_name = metric_entry["name"]
+      name = NAME_MAP.fetch(raw_name, raw_name)
       next if IGNORED_METRICS.include?(name)
 
       units = metric_entry["units"]

--- a/test/services/metrics_parser_test.rb
+++ b/test/services/metrics_parser_test.rb
@@ -64,6 +64,17 @@ class MetricsParserTest < ActiveSupport::TestCase
     assert_in_delta 1000.0, metric.value, 0.1
   end
 
+  test "normalizes weight_body_mass to weight" do
+    data = [{"name" => "weight_body_mass", "units" => "kg",
+             "data" => [{"qty" => 70.5, "date" => "2026-03-14 00:00:00 -0800"}]}]
+    result = MetricsParser.call(data)
+
+    assert_equal 1, result.created
+    metric = HealthMetric.find_by(metric_name: "weight")
+    assert_equal 70.5, metric.value
+    assert_nil HealthMetric.find_by(metric_name: "weight_body_mass")
+  end
+
   test "ignores excluded metrics" do
     ignored = [{"name" => "time_in_daylight", "units" => "min",
                 "data" => [{"qty" => 30, "date" => "2026-03-14 00:00:00 -0800"}]}]


### PR DESCRIPTION
## Summary
- Health Auto Export sends weight as `weight_body_mass` but the dashboard queries for `weight`, so webhook weight data was silently stored under the wrong name and never displayed
- Added `NAME_MAP` to `MetricsParser` to normalize `weight_body_mass` → `weight`
- Also fixed the existing `weight_body_mass` record in prod DB directly

## Test plan
- [x] New test verifies `weight_body_mass` gets stored as `weight`
- [x] All 86 existing tests pass
- [ ] After deploy, verify next webhook payload stores weight correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)