### PR TITLE
Add user notes to workout cards

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -20,4 +20,19 @@ class WorkoutsController < ApplicationController
     @workouts = workouts.limit(PER_PAGE).offset((@page - 1) * PER_PAGE)
     @total_pages = (@total_count.to_f / PER_PAGE).ceil
   end
+
+  def update
+    @workout = Workout.find(params[:id])
+    if @workout.update(workout_params)
+      redirect_back fallback_location: workouts_path, notice: "Note saved."
+    else
+      redirect_back fallback_location: workouts_path, alert: @workout.errors.full_messages.join(", ")
+    end
+  end
+
+  private
+
+  def workout_params
+    params.require(:workout).permit(:notes)
+  end
 end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Generic reusable modal controller for <dialog> elements.
+// Usage: wrap a <dialog> with data-controller="modal" and
+// use data-action="modal#open" / data-action="modal#close" on triggers.
+// Clicking the backdrop (outside the dialog content) closes the modal.
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  open() {
+    this.dialogTarget.showModal()
+  }
+
+  close() {
+    this.dialogTarget.close()
+  }
+
+  clickOutside(event) {
+    if (event.target === this.dialogTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/notes_modal_controller.js
+++ b/app/javascript/controllers/notes_modal_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["textarea", "counter", "form", "label"]
+
+  open(event) {
+    const { notes, url, workoutLabel } = event.currentTarget.dataset
+
+    this.formTarget.action = url
+    this.textareaTarget.value = notes || ""
+    this.labelTarget.textContent = workoutLabel || ""
+    this.updateCounter()
+
+    this.#modal.open()
+  }
+
+  updateCounter() {
+    const remaining = 280 - this.textareaTarget.value.length
+    this.counterTarget.textContent = `${remaining} characters remaining`
+  }
+
+  get #modal() {
+    return this.application.getControllerForElementAndIdentifier(this.element, "modal")
+  }
+}

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -4,4 +4,5 @@ class Workout < ApplicationRecord
   validates :started_at, presence: true
   validates :ended_at, presence: true
   validates :duration, presence: true
+  validates :notes, length: {maximum: 280}, allow_blank: true
 end

--- a/app/services/plan_adherence_generator.rb
+++ b/app/services/plan_adherence_generator.rb
@@ -73,7 +73,9 @@ class PlanAdherenceGenerator
       parts << w.workout_type
       parts << "#{(w.duration / 60.0).round} min"
       parts << "#{w.energy_burned.round} kcal" if w.energy_burned.present?
-      "- #{parts.join(", ")}"
+      line = "- #{parts.join(", ")}"
+      line << " — \"#{w.notes}\"" if w.notes.present?
+      line
     }.join("\n")
   end
 

--- a/app/services/plan_suggestion_generator.rb
+++ b/app/services/plan_suggestion_generator.rb
@@ -72,7 +72,9 @@ class PlanSuggestionGenerator
       parts << "#{(w.duration / 60.0).round} min"
       parts << "#{w.distance} #{w.distance_units}" if w.distance.present?
       parts << "#{w.energy_burned.round} kcal" if w.energy_burned.present?
-      "- #{parts.join(", ")}"
+      line = "- #{parts.join(", ")}"
+      line << " — \"#{w.notes}\"" if w.notes.present?
+      line
     }.join("\n")
   end
 
@@ -84,7 +86,9 @@ class PlanSuggestionGenerator
       parts = [w.workout_type]
       parts << "#{(w.duration / 60.0).round} min"
       parts << "#{w.energy_burned.round} kcal" if w.energy_burned.present?
-      "- #{parts.join(", ")}"
+      line = "- #{parts.join(", ")}"
+      line << " — \"#{w.notes}\"" if w.notes.present?
+      line
     }.join("\n")
   end
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -16,28 +16,13 @@
         <%= link_to "View all", workouts_path, class: "text-sm text-zinc-400 hover:text-zinc-200" %>
       </div>
       <% if @todays_workouts.any? %>
-        <div class="space-y-3">
+        <div class="space-y-3" data-controller="modal notes-modal">
           <% @todays_workouts.each do |workout| %>
             <%= render(CardComponent.new) do %>
-              <div class="flex items-center justify-between mb-2">
-                <span class="font-medium"><%= workout.workout_type %></span>
-                <span class="text-xs text-zinc-500"><%= workout.started_at.strftime("%-I:%M %p") %></span>
-              </div>
-              <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-zinc-400">
-                <span>
-                  <% hours = workout.duration.to_i / 3600 %>
-                  <% minutes = (workout.duration.to_i % 3600) / 60 %>
-                  <%= hours > 0 ? "#{hours}h #{minutes}m" : "#{minutes}m" %>
-                </span>
-                <% if workout.distance.present? && workout.distance > 0 %>
-                  <span><%= number_with_precision(workout.distance, precision: 1, strip_insignificant_zeros: true) %> <%= workout.distance_units %></span>
-                <% end %>
-                <% if workout.energy_burned.present? && workout.energy_burned > 0 %>
-                  <span><%= workout.energy_burned.to_i %> kcal</span>
-                <% end %>
-              </div>
+              <%= render "workouts/workout_card_content", workout: workout %>
             <% end %>
           <% end %>
+          <%= render "workouts/notes_dialog" %>
         </div>
       <% else %>
         <%= render(CardComponent.new) do %>

--- a/app/views/workouts/_notes_dialog.html.erb
+++ b/app/views/workouts/_notes_dialog.html.erb
@@ -1,0 +1,45 @@
+<%# Mobile: fullscreen dialog. Desktop: centered overlay with backdrop. %>
+<dialog data-modal-target="dialog"
+        data-action="click->modal#clickOutside"
+        class="bg-zinc-800 text-zinc-100 shadow-xl
+               fixed inset-0 m-0 w-full h-full max-w-full max-h-full
+               md:m-auto md:w-full md:max-w-md md:h-fit md:max-h-fit md:rounded-lg
+               backdrop:bg-black/60 backdrop:backdrop-blur-sm
+               open:flex open:flex-col">
+  <div class="flex-1 flex flex-col p-6 md:flex-none">
+    <%# Header with close X on mobile %>
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <h3 class="text-lg font-semibold">Workout Note</h3>
+        <p class="text-sm text-zinc-400" data-notes-modal-target="label"></p>
+      </div>
+      <button type="button" data-action="modal#close"
+              class="md:hidden text-zinc-400 hover:text-zinc-200 p-1">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+      </button>
+    </div>
+
+    <%= form_with url: "", method: :patch, data: { notes_modal_target: "form" } do |f| %>
+      <div class="mb-2">
+        <%= f.text_area :notes, name: "workout[notes]",
+            maxlength: 280,
+            rows: 4,
+            placeholder: "How did it feel?",
+            data: { notes_modal_target: "textarea", action: "input->notes-modal#updateCounter" },
+            class: "w-full bg-zinc-700 text-zinc-200 text-sm rounded px-3 py-2 border border-zinc-600 resize-none" %>
+      </div>
+
+      <p class="text-xs text-zinc-500 mb-4" data-notes-modal-target="counter">280 characters remaining</p>
+
+      <div class="flex justify-end gap-3">
+        <button type="button" data-action="modal#close"
+                class="hidden md:inline-block text-sm text-zinc-400 hover:text-zinc-200 px-3 py-2">
+          Cancel
+        </button>
+        <%= f.submit "Save", class: "bg-blue-600 hover:bg-blue-500 text-white text-sm rounded px-4 py-2 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</dialog>

--- a/app/views/workouts/_workout_card_content.html.erb
+++ b/app/views/workouts/_workout_card_content.html.erb
@@ -1,0 +1,37 @@
+<div class="flex items-center justify-between mb-2">
+  <span class="font-medium"><%= workout.workout_type %></span>
+  <span class="text-xs text-zinc-500"><%= workout.started_at.strftime("%-I:%M %p") %></span>
+</div>
+<div class="flex items-center justify-between gap-2">
+  <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-zinc-400">
+    <span>
+      <% hours = workout.duration.to_i / 3600 %>
+      <% minutes = (workout.duration.to_i % 3600) / 60 %>
+      <%= hours > 0 ? "#{hours}h #{minutes}m" : "#{minutes}m" %>
+    </span>
+    <% if workout.distance.present? && workout.distance > 0 %>
+      <span><%= number_with_precision(workout.distance, precision: 1, strip_insignificant_zeros: true) %> <%= workout.distance_units %></span>
+    <% end %>
+    <% avg_hr = workout.metadata&.dig("heartRate", "avg") %>
+    <% if avg_hr.present? %>
+      <span><%= avg_hr.to_i %> bpm</span>
+    <% end %>
+    <% if workout.energy_burned.present? && workout.energy_burned > 0 %>
+      <span><%= workout.energy_burned.to_i %> kcal</span>
+    <% end %>
+  </div>
+  <button type="button"
+          data-action="notes-modal#open"
+          data-notes="<%= workout.notes %>"
+          data-url="<%= workout_path(workout) %>"
+          data-workout-label="<%= "#{workout.workout_type} — #{workout.started_at.strftime('%b %-d, %-I:%M %p')}" %>"
+          class="text-zinc-500 hover:text-zinc-300 shrink-0"
+          title="<%= workout.notes.present? ? 'Edit note' : 'Add note' %>">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+    </svg>
+  </button>
+</div>
+<% if workout.notes.present? %>
+  <p class="text-xs text-zinc-500 italic mt-2 truncate">"<%= truncate(workout.notes, length: 60) %>"</p>
+<% end %>

--- a/app/views/workouts/index.html.erb
+++ b/app/views/workouts/index.html.erb
@@ -36,37 +36,23 @@
     <% if @workouts.any? %>
       <p class="text-sm text-zinc-500"><%= @total_count %> workout<%= @total_count == 1 ? "" : "s" %></p>
 
-      <%# Mobile: stacked cards %>
-      <div class="md:hidden space-y-3">
-        <% @workouts.each do |workout| %>
-          <%= render(CardComponent.new) do %>
-            <div class="flex items-center justify-between mb-2">
-              <span class="font-medium"><%= workout.workout_type %></span>
-              <span class="text-xs text-zinc-500"><%= workout.started_at.strftime("%b %-d") %></span>
-            </div>
-            <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-zinc-400">
-              <span>
-                <% hours = workout.duration.to_i / 3600 %>
-                <% minutes = (workout.duration.to_i % 3600) / 60 %>
-                <%= hours > 0 ? "#{hours}h #{minutes}m" : "#{minutes}m" %>
-              </span>
-              <% if workout.distance.present? && workout.distance > 0 %>
-                <span><%= number_with_precision(workout.distance, precision: 1, strip_insignificant_zeros: true) %> <%= workout.distance_units %></span>
+      <%# Mobile: stacked cards grouped by day %>
+      <div class="md:hidden" data-controller="modal notes-modal">
+        <% @workouts.group_by { |w| w.started_at.to_date }.each_with_index do |(date, workouts), i| %>
+          <h3 class="text-sm font-medium text-zinc-400 mb-2 <%= 'mt-6' unless i == 0 %>"><%= date.strftime("%a, %b %-d") %></h3>
+          <div class="space-y-3">
+            <% workouts.each do |workout| %>
+              <%= render(CardComponent.new) do %>
+                <%= render "workouts/workout_card_content", workout: workout %>
               <% end %>
-              <% avg_hr = workout.metadata&.dig("heartRate", "avg") %>
-              <% if avg_hr.present? %>
-                <span><%= avg_hr.to_i %> bpm</span>
-              <% end %>
-              <% if workout.energy_burned.present? && workout.energy_burned > 0 %>
-                <span><%= workout.energy_burned.to_i %> kcal</span>
-              <% end %>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         <% end %>
+        <%= render "workouts/notes_dialog" %>
       </div>
 
       <%# Desktop: table %>
-      <div class="hidden md:block">
+      <div class="hidden md:block" data-controller="modal notes-modal">
         <%= render(CardComponent.new(flush: true)) do %>
           <table class="min-w-full divide-y divide-zinc-700">
             <thead class="bg-zinc-700/50">
@@ -77,6 +63,7 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-zinc-400 uppercase">Distance</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-zinc-400 uppercase">Avg HR</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-zinc-400 uppercase">Energy</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-zinc-400 uppercase">Notes</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-zinc-700">
@@ -111,11 +98,25 @@
                       &mdash;
                     <% end %>
                   </td>
+                  <td class="px-6 py-4 text-sm text-zinc-400">
+                    <button type="button"
+                            data-action="notes-modal#open"
+                            data-notes="<%= workout.notes %>"
+                            data-url="<%= workout_path(workout) %>"
+                            data-workout-label="<%= "#{workout.workout_type} — #{workout.started_at.strftime('%b %-d, %-I:%M %p')}" %>"
+                            class="<%= workout.notes.present? ? 'text-blue-400 hover:text-blue-300' : 'text-zinc-500 hover:text-zinc-300' %>"
+                            title="<%= workout.notes if workout.notes.present? %>">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                      </svg>
+                    </button>
+                  </td>
                 </tr>
               <% end %>
             </tbody>
           </table>
         <% end %>
+        <%= render "workouts/notes_dialog" %>
       </div>
 
       <%# Pagination %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   get "dashboard/adherence", to: "dashboard#adherence"
   post "dashboard/adherence", to: "dashboard#regenerate_adherence", as: nil
 
-  resources :workouts, only: [:index]
+  resources :workouts, only: [:index, :update]
 
   root "dashboard#index"
 end

--- a/db/migrate/20260329191222_add_notes_to_workouts.rb
+++ b/db/migrate/20260329191222_add_notes_to_workouts.rb
@@ -1,0 +1,5 @@
+class AddNotesToWorkouts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workouts, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_29_030557) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_29_191222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -66,6 +66,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_29_030557) do
     t.decimal "energy_burned"
     t.string "external_id", null: false
     t.jsonb "metadata"
+    t.text "notes"
     t.datetime "started_at", null: false
     t.datetime "updated_at", null: false
     t.string "workout_type", null: false

--- a/docs/plans/issue-10.md
+++ b/docs/plans/issue-10.md
@@ -1,0 +1,123 @@
+# Issue #10: Add user notes to workout cards
+
+**Issue:** [#10](https://github.com/julesie/signals/issues/10)
+**Branch:** `issue-10-add-user-notes-to-workout-cards`
+**Status:** Executing
+**Created:** 2026-03-29
+
+---
+
+## Problem Summary
+
+Workouts currently display only raw health data (type, duration, distance, HR, energy) with no way for the user to add personal context. Notes like "knee felt tight" or "easy recovery pace" would make workout history more meaningful and give the LLM better context when generating daily suggestions and plan adherence assessments. This is the first user-editable field on workouts — all other data comes from the HealthKit API.
+
+## Key Findings
+
+### Current Architecture
+- **Workout model** (`app/models/workout.rb`): validates `external_id`, `workout_type`, `started_at`, `ended_at`, `duration`. No user-editable fields.
+- **CardComponent** (`app/components/card_component.rb`): generic wrapper, not workout-specific. Workout rendering is inline in views.
+- **Dashboard view** (`app/views/dashboard/index.html.erb:18-47`): renders today's workouts in CardComponents.
+- **Workouts index** (`app/views/workouts/index.html.erb:35-139`): mobile (stacked cards) and desktop (table) layouts with filtering/pagination.
+- **Routes** (`config/routes.rb`): only `resources :workouts, only: [:index]` — no update action exists.
+
+### LLM Integration
+- **Plan suggestion generator** (`app/services/plan_suggestion_generator.rb:65-77`): formats workouts as `"- date, type, duration, distance, energy"` for last 7 days + today.
+- **Plan adherence generator** (`app/services/plan_adherence_generator.rb:67-77`): similar format, includes 7-day and 30-day windows.
+- Neither currently includes any notes field.
+
+### Frontend Patterns
+- Turbo Rails + Stimulus available but minimal Stimulus usage.
+- No existing modal pattern in the codebase — dynamic content uses Turbo frames with lazy loading.
+- Tailwind CSS for styling.
+
+### Test Patterns
+- Minitest with fixtures, not RSpec.
+- Workout model tests: validation-focused (`test/models/workout_test.rb`).
+- Generator tests: mock LLM, assert context includes workout data (`test/services/plan_*_generator_test.rb`).
+- Integration tests: Devise helpers, assert response body content (`test/integration/workouts_test.rb`).
+
+## Design Decisions
+
+1. **Auth**: No user scoping — Devise `authenticate_user!` is sufficient. User-scoping deferred to [#11](https://github.com/julesie/signals/issues/11).
+2. **Turbo response**: Simple `redirect_back(fallback_location: workouts_path)` after save. No turbo_stream complexity — this is a low-frequency action.
+3. **Shared partial**: Extract one `_workout_card_content.html.erb` partial used by both dashboard and workouts index mobile cards. The dashboard currently omits avg HR — unify both to show the full data set (type, time, duration, distance, avg HR, energy, note).
+4. **Date/time display**: Card always shows time only (`%-I:%M %p`). Workouts index mobile view groups cards under day headings (e.g. "Mon, Mar 23"). Desktop table keeps the full date+time column as-is — no grouping.
+5. **Dialog**: Single page-level `<dialog>` rendered via a shared partial (`workouts/_notes_dialog.html.erb`), included at the bottom of dashboard and workouts index views.
+6. **Stimulus controller**: `notes_modal_controller` — pen icon has `data-*` attributes (workout ID, current note, form action URL). On click, controller populates the dialog's textarea and form action, then calls `showModal()`. Also handles live character counter.
+7. **Note preview on cards**: New row below the stats. Truncated to ~60 chars with ellipsis. Pen icon sits to the right, always visible (even when no note exists).
+   ```
+   Outdoor Run                    2:30 PM
+   32m  5.2 km  142 bpm  320 kcal
+   "Knee felt tight on hills..."     [pen]
+   ```
+8. **Desktop table**: Add a Notes column. Pen icon always shown. Hover shows note as tooltip when one exists. Click opens the edit modal.
+9. **LLM notes**: Only appended to workout lines when present. Format: `— "note text"` at the end of the line. No indication for workouts without notes.
+10. **Column type**: `text` (Postgres `text`, not `varchar`). 280-char limit enforced in model validation and UI only.
+
+## Proposed Approach
+
+### Database
+Add a nullable `notes` text column to workouts via migration.
+
+### Model
+Add `validates :notes, length: { maximum: 280 }, allow_blank: true` to Workout.
+
+### Routes & Controller
+Add `update` action to workouts resource: `resources :workouts, only: [:index, :update]`. The update action permits only `notes` via strong params, saves, and `redirect_back`.
+
+### UI — Shared workout card partial
+Extract `app/views/workouts/_workout_card_content.html.erb` from the existing dashboard and workouts index mobile markup. Unify to show: workout type, time, duration, distance, avg HR, energy, note preview + pen icon.
+
+### UI — Day grouping on workouts index
+Group `@workouts` by date on the mobile view, rendering a date heading (`%a, %b %-d`) before each day's cards. Desktop table unchanged.
+
+### UI — Notes dialog
+Single `<dialog>` in `app/views/workouts/_notes_dialog.html.erb`, rendered at page bottom on dashboard and workouts index. Contains a `<form>` with `<textarea>` (maxlength=280), live character counter, and save/cancel buttons. Form action set dynamically by Stimulus.
+
+### Stimulus controller
+`notes_modal_controller` handles:
+- Opening the dialog (populate textarea + form action from `data-*` attributes, call `showModal()`)
+- Live character counter on textarea input
+- Closing the dialog on cancel
+
+### LLM Prompt Integration
+In both generators' `format_workouts` and `format_todays_workouts`, append `— "note"` when `w.notes.present?`:
+```
+- Mon Mar 23, Running, 32 min, 5.2 km, 320 kcal — "knee felt tight on hills"
+```
+
+## Step-by-Step Tasks
+
+### Batch 1: Database & Model
+- [ ] 1. Migration: add `notes` (text, nullable) to workouts table
+- [ ] 2. Model: add length validation for notes
+- [ ] 3. Model test: validate 280-char limit, valid with blank/nil notes
+
+### Batch 2: Routes & Controller
+- [ ] 4. Routes: add `update` to workouts resource
+- [ ] 5. Controller: add `update` action with strong params (notes only), `redirect_back`
+- [ ] 6. Integration test: PATCH workout with note, assert persistence and redirect
+
+### Batch 3: Frontend — Stimulus & Dialog
+- [ ] 7. Stimulus controller: `notes_modal_controller` (open/close dialog, populate form, character counter)
+- [ ] 8. Dialog partial: `workouts/_notes_dialog.html.erb` with form, textarea, counter, save/cancel
+
+### Batch 4: View Updates
+- [ ] 9. Shared partial: extract `workouts/_workout_card_content.html.erb` with note preview + pen icon
+- [ ] 10. Update dashboard view to use the shared partial
+- [ ] 11. Update workouts index mobile view: day-group headings + shared partial
+- [ ] 12. Update workouts index desktop table: add Notes column with pen icon + tooltip
+- [ ] 13. Render `_notes_dialog` partial at bottom of dashboard and workouts index views
+
+### Batch 5: LLM Integration
+- [ ] 14. Update `format_workouts` and `format_todays_workouts` in PlanSuggestionGenerator to include notes
+- [ ] 15. Update `format_workouts` in PlanAdherenceGenerator to include notes
+- [ ] 16. Generator tests: assert notes appear in LLM context when present
+
+## Open Questions / Unknowns
+
+All resolved. See Design Decisions above.
+
+---
+
+*This plan is a living document — update it as understanding evolves.*

--- a/test/integration/workouts_test.rb
+++ b/test/integration/workouts_test.rb
@@ -52,4 +52,23 @@ class WorkoutsTest < ActionDispatch::IntegrationTest
     get workouts_path
     assert_response :redirect
   end
+
+  test "update saves workout notes" do
+    patch workout_path(@run), params: {workout: {notes: "Knee felt tight"}}
+    assert_response :redirect
+    assert_equal "Knee felt tight", @run.reload.notes
+  end
+
+  test "update rejects notes exceeding 280 characters" do
+    patch workout_path(@run), params: {workout: {notes: "a" * 281}}
+    assert_response :redirect
+    assert_nil @run.reload.notes
+  end
+
+  test "update requires authentication" do
+    sign_out @user
+    patch workout_path(@run), params: {workout: {notes: "test"}}
+    assert_response :redirect
+    assert_nil @run.reload.notes
+  end
 end

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -20,4 +20,41 @@ class WorkoutTest < ActiveSupport::TestCase
     duplicate = Workout.new(external_id: "ABC-123", workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
     assert_not duplicate.valid?
   end
+
+  test "valid with blank notes" do
+    workout = Workout.new(
+      external_id: "NOTE-1", workout_type: "Running",
+      started_at: 1.hour.ago, ended_at: Time.current,
+      duration: 3600, notes: ""
+    )
+    assert workout.valid?
+  end
+
+  test "valid with nil notes" do
+    workout = Workout.new(
+      external_id: "NOTE-2", workout_type: "Running",
+      started_at: 1.hour.ago, ended_at: Time.current,
+      duration: 3600, notes: nil
+    )
+    assert workout.valid?
+  end
+
+  test "valid with notes within 280 characters" do
+    workout = Workout.new(
+      external_id: "NOTE-3", workout_type: "Running",
+      started_at: 1.hour.ago, ended_at: Time.current,
+      duration: 3600, notes: "Knee felt tight on hills"
+    )
+    assert workout.valid?
+  end
+
+  test "invalid with notes exceeding 280 characters" do
+    workout = Workout.new(
+      external_id: "NOTE-4", workout_type: "Running",
+      started_at: 1.hour.ago, ended_at: Time.current,
+      duration: 3600, notes: "a" * 281
+    )
+    assert_not workout.valid?
+    assert_includes workout.errors[:notes], "is too long (maximum is 280 characters)"
+  end
 end

--- a/test/services/plan_adherence_generator_test.rb
+++ b/test/services/plan_adherence_generator_test.rb
@@ -49,6 +49,26 @@ class PlanAdherenceGeneratorTest < ActiveSupport::TestCase
     assert_includes captured_prompt, "Last 30 Days"
   end
 
+  test "includes workout notes in the context when present" do
+    Workout.create!(
+      external_id: "adherence-noted",
+      workout_type: "Running",
+      started_at: 2.days.ago,
+      ended_at: 2.days.ago + 30.minutes,
+      duration: 1800,
+      energy_burned: 300,
+      notes: "Felt strong today"
+    )
+
+    captured_prompt = nil
+
+    stub_llm_chat(@fake_response, capture: ->(prompt) { captured_prompt = prompt }) do
+      PlanAdherenceGenerator.call(@plan)
+    end
+
+    assert_includes captured_prompt, "Felt strong today"
+  end
+
   private
 
   def stub_llm_chat(response, capture: nil, &block)

--- a/test/services/plan_suggestion_generator_test.rb
+++ b/test/services/plan_suggestion_generator_test.rb
@@ -82,6 +82,62 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
     assert_includes captured_prompt, "Traditional Strength Training"
   end
 
+  test "includes workout notes in the context when present" do
+    Workout.create!(
+      external_id: "noted-workout",
+      workout_type: "Running",
+      started_at: 2.days.ago,
+      ended_at: 2.days.ago + 30.minutes,
+      duration: 1800,
+      notes: "Knee felt tight on hills"
+    )
+
+    captured_prompt = nil
+
+    stub_llm_chat(@fake_response, capture: ->(prompt) { captured_prompt = prompt }) do
+      PlanSuggestionGenerator.call(@plan)
+    end
+
+    assert_includes captured_prompt, "Knee felt tight on hills"
+  end
+
+  test "includes today's workout notes in the context" do
+    Workout.create!(
+      external_id: "today-noted",
+      workout_type: "Running",
+      started_at: 1.hour.ago,
+      ended_at: Time.current,
+      duration: 1800,
+      notes: "Easy recovery pace"
+    )
+
+    captured_prompt = nil
+
+    stub_llm_chat(@fake_response, capture: ->(prompt) { captured_prompt = prompt }) do
+      PlanSuggestionGenerator.call(@plan)
+    end
+
+    assert_includes captured_prompt, "Easy recovery pace"
+  end
+
+  test "omits notes from context when not present" do
+    Workout.create!(
+      external_id: "no-note-workout",
+      workout_type: "Running",
+      started_at: 2.days.ago,
+      ended_at: 2.days.ago + 30.minutes,
+      duration: 1800
+    )
+
+    captured_prompt = nil
+
+    stub_llm_chat(@fake_response, capture: ->(prompt) { captured_prompt = prompt }) do
+      PlanSuggestionGenerator.call(@plan)
+    end
+
+    refute_match(/— "/, captured_prompt)
+  end
+
   test "context says no workouts today when none exist" do
     captured_prompt = nil
 


### PR DESCRIPTION
## Summary
- Add a notes field (max 280 chars) to workouts, editable via a modal dialog triggered by a pen icon on workout cards and the desktop table
- Mobile workouts index now groups cards by day; desktop table gets a Notes column with blue icon indicator for existing notes
- Both LLM generators (plan suggestion + plan adherence) include workout notes in their context when present

## Test Plan
- [x] Model tests: validates 280-char limit, accepts blank/nil
- [x] Integration tests: PATCH saves notes, rejects over-limit, requires auth
- [x] Generator tests: notes appear in LLM context when present, omitted when absent
- [x] Brakeman security scan: 0 warnings
- [x] Full suite: 97 tests, 0 failures

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)