### PR TITLE
fix: correct database and service plan names in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 databases:
   - name: signals-db
-    plan: starter
+    plan: basic-256mb
     databaseName: signals
     user: signals
 


### PR DESCRIPTION
Use basic-256mb for Postgres (new Render plan naming) and starter for the web service to match actual account tier.