### PR TITLE
fix: use db:prepare to create missing SolidQueue/SolidCache tables

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     runtime: docker
     plan: starter
     dockerfilePath: ./Dockerfile
-    preDeployCommand: "bundle exec rails db:migrate"
+    preDeployCommand: "bundle exec rails db:prepare"
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
db:migrate only runs pending migrations but won't create tables for multi-database configs (queue, cache) if they've never been set up. db:prepare handles both creation and migration across all databases.