### PR TITLE
fix: explicitly load queue and cache schemas on deploy

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     runtime: docker
     plan: starter
     dockerfilePath: ./Dockerfile
-    preDeployCommand: "bundle exec rails db:prepare"
+    preDeployCommand: "bundle exec rails db:prepare db:schema:load:queue db:schema:load:cache"
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
The queue and cache databases use schema files (not migrations), so db:prepare alone won't create their tables when the database already exists. Explicitly load db:schema:load:queue and db:schema:load:cache.