### PR TITLE
Scope workouts and health metrics to authenticated user

### DIFF
--- a/app/controllers/api/v1/health_data_controller.rb
+++ b/app/controllers/api/v1/health_data_controller.rb
@@ -2,12 +2,14 @@ class Api::V1::HealthDataController < ActionController::API
   before_action :authenticate_token!
 
   def create
-    health_payload = HealthPayload.create!(
+    user = User.find_by!(email: "jules@julescoleman.com")
+
+    health_payload = user.health_payloads.create!(
       raw_json: JSON.parse(request.raw_post),
       status: "pending"
     )
 
-    result = HealthDataProcessor.call(health_payload)
+    result = HealthDataProcessor.call(health_payload, user: user)
 
     if result.success
       render json: {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,15 +4,15 @@ class DashboardController < ApplicationController
 
   def index
     @plan = current_user.plan
-    @todays_workouts = Workout.where(started_at: Date.current.all_day).order(started_at: :desc)
+    @todays_workouts = current_user.workouts.where(started_at: Date.current.all_day).order(started_at: :desc)
     @latest_metrics = METRIC_TYPES.filter_map do |name|
-      HealthMetric.where(metric_name: name).order(recorded_at: :desc).first
+      current_user.health_metrics.where(metric_name: name).order(recorded_at: :desc).first
     end
-    @latest_sleep = HealthMetric.where(metric_name: "sleep_analysis").order(recorded_at: :desc).first
+    @latest_sleep = current_user.health_metrics.where(metric_name: "sleep_analysis").order(recorded_at: :desc).first
     @pipeline_stats = {
-      total_payloads: HealthPayload.count,
-      last_received: HealthPayload.order(created_at: :desc).first&.created_at,
-      failed_count: HealthPayload.where(status: "failed").count
+      total_payloads: current_user.health_payloads.count,
+      last_received: current_user.health_payloads.order(created_at: :desc).first&.created_at,
+      failed_count: current_user.health_payloads.where(status: "failed").count
     }
   end
 
@@ -63,7 +63,7 @@ class DashboardController < ApplicationController
   end
 
   def load_active_calories
-    metrics = HealthMetric.where(metric_name: "active_energy", recorded_at: 7.days.ago..)
+    metrics = current_user.health_metrics.where(metric_name: "active_energy", recorded_at: 7.days.ago..)
     daily = metrics.group_by { |m| m.recorded_at.to_date }.transform_values { |ms| ms.sum(&:value).round }
 
     @active_calories_days = (6.days.ago.to_date..Date.current).map do |date|

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -2,7 +2,7 @@ class WorkoutsController < ApplicationController
   PER_PAGE = 20
 
   def index
-    workouts = Workout.order(started_at: :desc)
+    workouts = current_user.workouts.order(started_at: :desc)
     workouts = workouts.where(workout_type: params[:workout_type]) if params[:workout_type].present?
 
     if params[:from].present? || params[:to].present?
@@ -13,7 +13,7 @@ class WorkoutsController < ApplicationController
       workouts = workouts.where(started_at: 30.days.ago..)
     end
 
-    @workout_types = Workout.distinct.pluck(:workout_type).sort
+    @workout_types = current_user.workouts.distinct.pluck(:workout_type).sort
 
     @page = (params[:page] || 1).to_i
     @total_count = workouts.count
@@ -22,7 +22,7 @@ class WorkoutsController < ApplicationController
   end
 
   def update
-    @workout = Workout.find(params[:id])
+    @workout = current_user.workouts.find(params[:id])
     if @workout.update(workout_params)
       redirect_back fallback_location: workouts_path, notice: "Note saved."
     else

--- a/app/models/health_metric.rb
+++ b/app/models/health_metric.rb
@@ -1,7 +1,9 @@
 class HealthMetric < ApplicationRecord
+  belongs_to :user
+
   validates :metric_name, presence: true
   validates :recorded_at, presence: true
   validates :value, presence: true
   validates :units, presence: true
-  validates :metric_name, uniqueness: {scope: :recorded_at}
+  validates :metric_name, uniqueness: {scope: [:user_id, :recorded_at]}
 end

--- a/app/models/health_payload.rb
+++ b/app/models/health_payload.rb
@@ -1,4 +1,6 @@
 class HealthPayload < ApplicationRecord
+  belongs_to :user
+
   validates :raw_json, presence: true
   validates :status, presence: true, inclusion: {in: %w[pending processed failed]}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,7 @@ class User < ApplicationRecord
     :rememberable, :validatable
 
   has_one :plan, dependent: :destroy
+  has_many :workouts, dependent: :delete_all
+  has_many :health_metrics, dependent: :delete_all
+  has_many :health_payloads, dependent: :delete_all
 end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,4 +1,6 @@
 class Workout < ApplicationRecord
+  belongs_to :user
+
   validates :external_id, presence: true, uniqueness: true
   validates :workout_type, presence: true
   validates :started_at, presence: true

--- a/app/services/csv_importer.rb
+++ b/app/services/csv_importer.rb
@@ -29,13 +29,14 @@ class CsvImporter
   KJ_TO_KCAL = 4.184
   KJ_METRICS = %w[active_energy basal_energy_burned].freeze
 
-  def self.call(metrics_csv_path:, workouts_csv_path: nil)
-    new(metrics_csv_path: metrics_csv_path, workouts_csv_path: workouts_csv_path).call
+  def self.call(metrics_csv_path:, user:, workouts_csv_path: nil)
+    new(metrics_csv_path: metrics_csv_path, user: user, workouts_csv_path: workouts_csv_path).call
   end
 
-  def initialize(metrics_csv_path:, workouts_csv_path: nil)
+  def initialize(metrics_csv_path:, user:, workouts_csv_path: nil)
     @metrics_csv_path = metrics_csv_path
     @workouts_csv_path = workouts_csv_path
+    @user = user
   end
 
   def call
@@ -134,12 +135,12 @@ class CsvImporter
         metadata: build_workout_metadata(row)
       }
 
-      existing = Workout.find_by(external_id: external_id)
+      existing = @user.workouts.find_by(external_id: external_id)
       if existing
         existing.update!(**attrs)
         updated += 1
       else
-        Workout.create!(external_id: external_id, **attrs)
+        @user.workouts.create!(external_id: external_id, **attrs)
         created += 1
       end
     end
@@ -162,12 +163,12 @@ class CsvImporter
   end
 
   def upsert_metric(name:, recorded_at:, value:, units:, metadata: nil)
-    existing = HealthMetric.find_by(metric_name: name, recorded_at: recorded_at)
+    existing = @user.health_metrics.find_by(metric_name: name, recorded_at: recorded_at)
     if existing
       existing.update!(value: value, units: units, metadata: metadata)
       [0, 1]
     else
-      HealthMetric.create!(metric_name: name, recorded_at: recorded_at, value: value, units: units, metadata: metadata)
+      @user.health_metrics.create!(metric_name: name, recorded_at: recorded_at, value: value, units: units, metadata: metadata)
       [1, 0]
     end
   end

--- a/app/services/health_data_processor.rb
+++ b/app/services/health_data_processor.rb
@@ -1,12 +1,13 @@
 class HealthDataProcessor
   Result = Struct.new(:success, :metrics_created, :metrics_updated, :metrics_skipped, :workouts_created, :workouts_skipped, keyword_init: true)
 
-  def self.call(health_payload)
-    new(health_payload).call
+  def self.call(health_payload, user:)
+    new(health_payload, user: user).call
   end
 
-  def initialize(health_payload)
+  def initialize(health_payload, user:)
     @health_payload = health_payload
+    @user = user
   end
 
   def call
@@ -18,8 +19,8 @@ class HealthDataProcessor
       metrics_data = data["metrics"] || []
       workouts_data = data["workouts"] || []
 
-      metrics_result = MetricsParser.call(metrics_data)
-      workouts_result = WorkoutParser.call(workouts_data)
+      metrics_result = MetricsParser.call(metrics_data, user: @user)
+      workouts_result = WorkoutParser.call(workouts_data, user: @user)
       @health_payload.update!(status: "processed")
     end
 

--- a/app/services/health_data_reprocessor.rb
+++ b/app/services/health_data_reprocessor.rb
@@ -4,10 +4,25 @@ class HealthDataReprocessor
   end
 
   def call
+    results = {}
+
+    HealthPayload.select(:user_id).distinct.pluck(:user_id).each do |user_id|
+      user = User.find(user_id)
+      results[user_id] = reprocess_for_user(user)
+    end
+
+    HealthPayload.update_all(status: "processed", error_message: nil)
+
+    results
+  end
+
+  private
+
+  def reprocess_for_user(user)
     metrics_by_name = {}
     workouts_by_id = {}
 
-    HealthPayload.order(:created_at).find_each do |payload|
+    user.health_payloads.order(:created_at).find_each do |payload|
       data = payload.raw_json["data"]
       next unless data
 
@@ -35,15 +50,13 @@ class HealthDataReprocessor
       {"name" => name, "units" => entry["units"], "data" => entry["data_by_ts"].values}
     end
 
-    # Clear and reprocess as single merged dataset
+    # Clear this user's data and reprocess from merged payloads
     ActiveRecord::Base.transaction do
-      HealthMetric.delete_all
-      Workout.delete_all
+      user.health_metrics.delete_all
+      user.workouts.delete_all
 
-      metrics_result = MetricsParser.call(merged_metrics)
-      workouts_result = WorkoutParser.call(workouts_by_id.values)
-
-      HealthPayload.update_all(status: "processed", error_message: nil)
+      metrics_result = MetricsParser.call(merged_metrics, user: user)
+      workouts_result = WorkoutParser.call(workouts_by_id.values, user: user)
 
       {metrics: metrics_result, workouts: workouts_result}
     end

--- a/app/services/metrics_parser.rb
+++ b/app/services/metrics_parser.rb
@@ -15,12 +15,13 @@ class MetricsParser
   KJ_TO_KCAL_METRICS = %w[active_energy basal_energy_burned].freeze
   KJ_TO_KCAL = 4.184
 
-  def self.call(metrics_data)
-    new(metrics_data).call
+  def self.call(metrics_data, user:)
+    new(metrics_data, user: user).call
   end
 
-  def initialize(metrics_data)
+  def initialize(metrics_data, user:)
     @metrics_data = metrics_data
+    @user = user
   end
 
   def call
@@ -47,12 +48,12 @@ class MetricsParser
         end
         stored_units = convert ? "kcal" : units
 
-        existing = HealthMetric.find_by(metric_name: name, recorded_at: recorded_at)
+        existing = @user.health_metrics.find_by(metric_name: name, recorded_at: recorded_at)
         if existing
           existing.update!(value: value, units: stored_units, metadata: metadata)
           updated += 1
         else
-          HealthMetric.create!(
+          @user.health_metrics.create!(
             metric_name: name,
             recorded_at: recorded_at,
             value: value,

--- a/app/services/plan_adherence_generator.rb
+++ b/app/services/plan_adherence_generator.rb
@@ -65,7 +65,7 @@ class PlanAdherenceGenerator
   end
 
   def format_workouts(since)
-    workouts = Workout.where(started_at: since..).order(started_at: :asc)
+    workouts = @plan.user.workouts.where(started_at: since..).order(started_at: :asc)
     return "No workouts recorded." if workouts.empty?
 
     workouts.map { |w|
@@ -80,7 +80,7 @@ class PlanAdherenceGenerator
   end
 
   def format_active_energy
-    metrics = HealthMetric.where(metric_name: "active_energy", recorded_at: 7.days.ago..)
+    metrics = @plan.user.health_metrics.where(metric_name: "active_energy", recorded_at: 7.days.ago..)
     return "No active energy data." if metrics.empty?
 
     daily = metrics.group_by { |m| m.recorded_at.to_date }.transform_values { |ms| ms.sum(&:value) }

--- a/app/services/plan_suggestion_generator.rb
+++ b/app/services/plan_suggestion_generator.rb
@@ -63,7 +63,7 @@ class PlanSuggestionGenerator
   end
 
   def format_workouts
-    workouts = Workout.where(started_at: 7.days.ago..).order(started_at: :asc)
+    workouts = @plan.user.workouts.where(started_at: 7.days.ago..).order(started_at: :asc)
     return "No workouts recorded." if workouts.empty?
 
     workouts.map { |w|
@@ -79,7 +79,7 @@ class PlanSuggestionGenerator
   end
 
   def format_todays_workouts
-    workouts = Workout.where(started_at: Date.current.all_day).order(started_at: :asc)
+    workouts = @plan.user.workouts.where(started_at: Date.current.all_day).order(started_at: :asc)
     return "No workouts completed yet today." if workouts.empty?
 
     workouts.map { |w|
@@ -93,7 +93,7 @@ class PlanSuggestionGenerator
   end
 
   def format_metrics
-    metrics = HealthMetric.where(recorded_at: 7.days.ago..)
+    metrics = @plan.user.health_metrics.where(recorded_at: 7.days.ago..)
     return "No metrics recorded." if metrics.empty?
 
     summary = []

--- a/app/services/workout_parser.rb
+++ b/app/services/workout_parser.rb
@@ -4,12 +4,13 @@ class WorkoutParser
   COMMON_FIELDS = %w[id name start end duration location isIndoor].freeze
   KJ_TO_KCAL = 4.184
 
-  def self.call(workouts_data)
-    new(workouts_data).call
+  def self.call(workouts_data, user:)
+    new(workouts_data, user: user).call
   end
 
-  def initialize(workouts_data)
+  def initialize(workouts_data, user:)
     @workouts_data = workouts_data
+    @user = user
   end
 
   def call
@@ -19,10 +20,10 @@ class WorkoutParser
     @workouts_data.each do |workout_data|
       external_id = workout_data["id"]
 
-      if Workout.exists?(external_id: external_id)
+      if @user.workouts.exists?(external_id: external_id)
         skipped += 1
       else
-        Workout.create!(
+        @user.workouts.create!(
           external_id: external_id,
           workout_type: workout_data["name"],
           started_at: Time.parse(workout_data["start"]),

--- a/db/migrate/20260329214206_add_user_to_workouts_health_metrics_health_payloads.rb
+++ b/db/migrate/20260329214206_add_user_to_workouts_health_metrics_health_payloads.rb
@@ -1,0 +1,36 @@
+class AddUserToWorkoutsHealthMetricsHealthPayloads < ActiveRecord::Migration[8.1]
+  def up
+    # Add nullable user_id columns
+    add_reference :workouts, :user, null: true, foreign_key: true
+    add_reference :health_metrics, :user, null: true, foreign_key: true
+    add_reference :health_payloads, :user, null: true, foreign_key: true
+
+    # Backfill all existing records to the single existing user
+    user_id = User.find_by!(email: "jules@julescoleman.com").id
+    Workout.update_all(user_id: user_id)
+    HealthMetric.update_all(user_id: user_id)
+    HealthPayload.update_all(user_id: user_id)
+
+    # Make user_id NOT NULL now that all records are backfilled
+    change_column_null :workouts, :user_id, false
+    change_column_null :health_metrics, :user_id, false
+    change_column_null :health_payloads, :user_id, false
+
+    # Replace the old unique index on health_metrics with one scoped to user
+    remove_index :health_metrics, [:metric_name, :recorded_at]
+    add_index :health_metrics, [:user_id, :metric_name, :recorded_at], unique: true
+
+    # Add composite index for common query patterns
+    add_index :workouts, [:user_id, :started_at]
+  end
+
+  def down
+    remove_index :workouts, [:user_id, :started_at]
+    remove_index :health_metrics, [:user_id, :metric_name, :recorded_at]
+    add_index :health_metrics, [:metric_name, :recorded_at], unique: true
+
+    remove_reference :health_payloads, :user
+    remove_reference :health_metrics, :user
+    remove_reference :workouts, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_29_191222) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_29_214206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,8 +21,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_29_191222) do
     t.datetime "recorded_at", null: false
     t.string "units", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.decimal "value", null: false
-    t.index ["metric_name", "recorded_at"], name: "index_health_metrics_on_metric_name_and_recorded_at", unique: true
+    t.index ["user_id", "metric_name", "recorded_at"], name: "idx_on_user_id_metric_name_recorded_at_c228f30335", unique: true
+    t.index ["user_id"], name: "index_health_metrics_on_user_id"
   end
 
   create_table "health_payloads", force: :cascade do |t|
@@ -31,6 +33,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_29_191222) do
     t.jsonb "raw_json", null: false
     t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_health_payloads_on_user_id"
   end
 
   create_table "plans", force: :cascade do |t|
@@ -69,9 +73,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_29_191222) do
     t.text "notes"
     t.datetime "started_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.string "workout_type", null: false
     t.index ["external_id"], name: "index_workouts_on_external_id", unique: true
+    t.index ["user_id", "started_at"], name: "index_workouts_on_user_id_and_started_at"
+    t.index ["user_id"], name: "index_workouts_on_user_id"
   end
 
+  add_foreign_key "health_metrics", "users"
+  add_foreign_key "health_payloads", "users"
   add_foreign_key "plans", "users"
+  add_foreign_key "workouts", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@ if metrics_csv.exist?
   puts "Importing historical health data..."
   result = CsvImporter.call(
     metrics_csv_path: metrics_csv.to_s,
+    user: user,
     workouts_csv_path: workouts_csv.exist? ? workouts_csv.to_s : nil
   )
   puts "  Metrics: #{result.metrics_created} created, #{result.metrics_updated} updated"

--- a/docs/plans/issue-11.md
+++ b/docs/plans/issue-11.md
@@ -1,0 +1,121 @@
+# Issue #11: Scope workouts and health metrics to the authenticated user
+
+**Issue:** [#11](https://github.com/julesie/signals/issues/11)
+**Branch:** `issue-11-scope-workouts-health-metrics-to-user`
+**Status:** Done
+**Created:** 2026-03-29
+
+---
+
+## Problem Summary
+
+Workouts and health metrics have no `user_id` column — all queries are global. Any authenticated user can view and edit all records. The LLM generators (plan suggestions, adherence) mix data from all users. The API webhook ingestion creates records with no user association. The Plan model already follows the correct pattern (`belongs_to :user`); Workout and HealthMetric need the same treatment.
+
+## Key Findings
+
+### What's already scoped
+- `Plan` has `belongs_to :user`, `user_id` FK, uniqueness constraint — correct pattern to follow
+- `PlansController` uses `current_user.plan` — good
+
+### What's unscoped (the problem)
+- **WorkoutsController#index** — `Workout.order(started_at: :desc)` returns all users' workouts
+- **WorkoutsController#update** — `Workout.find(params[:id])` can edit any user's workout
+- **DashboardController#index** — `Workout.where(started_at: Date.current.all_day)` and `HealthMetric.where(metric_name:...)` are global
+- **DashboardController#load_active_calories** — global HealthMetric query
+- **PlanSuggestionGenerator** — receives `@plan` (has user) but queries `Workout.where(...)` and `HealthMetric.where(...)` globally
+- **PlanAdherenceGenerator** — same issue
+- **MetricsParser** — uniqueness by `(metric_name, recorded_at)` only; two users with same metric at same time = overwrite
+- **WorkoutParser** — no user context
+
+### API ingestion flow
+```
+Apple HealthKit → Webhook → Api::V1::HealthDataController (token auth)
+  → HealthPayload.create! → HealthDataProcessor → MetricsParser + WorkoutParser
+```
+- Single global `WEBHOOK_AUTH_TOKEN`, no user identifier
+- HealthPayload has no user_id
+- Parsers create records with no user association
+
+### Files that need changes
+| File | Change |
+|------|--------|
+| Migration (new) | Add `user_id` FK to `workouts` and `health_metrics`, update uniqueness indexes |
+| `app/models/user.rb` | Add `has_many :workouts` and `has_many :health_metrics` |
+| `app/models/workout.rb` | Add `belongs_to :user` |
+| `app/models/health_metric.rb` | Add `belongs_to :user`, update uniqueness scope |
+| `app/models/health_payload.rb` | Add `belongs_to :user` |
+| `app/controllers/workouts_controller.rb` | Scope all queries through `current_user.workouts` |
+| `app/controllers/dashboard_controller.rb` | Scope workout/metric queries through `current_user` |
+| `app/controllers/api/v1/health_data_controller.rb` | Resolve user from token, pass to processor |
+| `app/services/health_data_processor.rb` | Accept and pass user context |
+| `app/services/metrics_parser.rb` | Accept user, create records with `user_id` |
+| `app/services/workout_parser.rb` | Accept user, create records with `user_id` |
+| `app/services/health_data_reprocessor.rb` | Scope delete/recreate to user |
+| `app/services/csv_importer.rb` | Accept user, scope queries through user associations |
+| `db/seeds.rb` | Pass user to CsvImporter |
+| `app/services/plan_suggestion_generator.rb` | Scope queries through `@plan.user` |
+| `app/services/plan_adherence_generator.rb` | Scope queries through `@plan.user` |
+| Tests | Add cross-user isolation tests, update fixtures |
+
+## Proposed Approach
+
+### 1. Migration
+- Add `user_id` (bigint, NOT NULL, FK) to `workouts` and `health_metrics`
+- Add `user_id` (bigint, FK) to `health_payloads`
+- Backfill existing records to `User.find_by!(email: 'jules@julescoleman.com')`
+- Update unique indexes: `health_metrics` uniqueness becomes `(user_id, metric_name, recorded_at)`, `workouts` keeps `external_id` unique (Apple HealthKit IDs are globally unique)
+- Add composite indexes for query performance: `(user_id, started_at)` on workouts, `(user_id, metric_name, recorded_at)` on health_metrics
+
+### 2. Models
+- Add `belongs_to :user` on Workout, HealthMetric, HealthPayload
+- Add `has_many` associations on User with `dependent: :delete_all`
+- Update HealthMetric uniqueness validation to scope by `user_id`
+
+### 3. Controllers
+- All Workout/HealthMetric queries go through `current_user.workouts` / `current_user.health_metrics`
+- WorkoutsController#update scoped: `current_user.workouts.find(params[:id])`
+
+### 4. API ingestion — hardcode to existing user for now
+- After authenticating the global webhook token, look up the single user (`jules@julescoleman.com`) and associate incoming data with them
+- Pass user through: `HealthDataProcessor → MetricsParser/WorkoutParser`
+- HealthPayload gets associated with user
+- Per-user webhook tokens deferred until a second user is needed
+
+### 5. LLM generators
+- Both generators already receive `@plan` which has `@plan.user`
+- Change queries to `@plan.user.workouts.where(...)` and `@plan.user.health_metrics.where(...)`
+
+### 6. HealthDataReprocessor
+- Group payloads by `user_id`, delete only that user's workouts/metrics, replay their payloads
+
+### 7. CsvImporter
+- Accept `user:` keyword arg, scope all queries through `user.workouts` / `user.health_metrics`
+- Update `seeds.rb` to pass user
+
+## Step-by-Step Tasks
+
+- [ ] 1. Migration: add `user_id` to workouts, health_metrics, health_payloads; backfill to `jules@julescoleman.com`; add NOT NULL + indexes
+- [ ] 2. Models: add associations (`belongs_to :user`, `has_many` with `dependent: :delete_all`) and update validations
+- [ ] 3. Update API controller to look up `jules@julescoleman.com` and pass user to processor
+- [ ] 4. Thread user through HealthDataProcessor → MetricsParser → WorkoutParser
+- [ ] 5. Update CsvImporter to accept user, scope queries; update seeds.rb
+- [ ] 6. Update HealthDataReprocessor to scope deletes per-user
+- [ ] 7. Scope WorkoutsController queries to current_user
+- [ ] 8. Scope DashboardController queries to current_user
+- [ ] 9. Scope PlanSuggestionGenerator and PlanAdherenceGenerator to plan's user
+- [ ] 10. Update tests: fixtures, cross-user isolation, API tests
+
+## Open Questions / Unknowns
+
+All resolved during alignment:
+- ~~Per-user webhook tokens~~ Hardcode to `jules@julescoleman.com` for now. Revisit if a second user is added.
+- ~~HealthDataReprocessor scope~~ Scope deletes per-user: group payloads by user, delete that user's records, replay.
+- ~~External ID uniqueness~~ Keep globally unique (Apple HealthKit UUIDs are globally unique).
+- ~~Migration strategy~~ Single migration (data volume is small).
+- ~~Backfill target~~ Use `User.find_by!(email: 'jules@julescoleman.com')`, not `User.first`.
+- ~~dependent option~~ Use `delete_all` not `destroy` (no callbacks on these models).
+- ~~CsvImporter~~ Added to scope — accept user, pass through seeds.rb.
+
+---
+
+*This plan is a living document — update it as understanding evolves.*

--- a/test/controllers/api/v1/health_data_controller_test.rb
+++ b/test/controllers/api/v1/health_data_controller_test.rb
@@ -2,6 +2,9 @@ require "test_helper"
 
 class Api::V1::HealthDataControllerTest < ActionDispatch::IntegrationTest
   setup do
+    @user = User.find_or_create_by!(email: "jules@julescoleman.com") do |u|
+      u.password = "password123!"
+    end
     @payload = JSON.parse(File.read(Rails.root.join("docs/example_workout_payload.json")))
     @token = "test-webhook-token"
     @original_token = ENV["WEBHOOK_AUTH_TOKEN"]
@@ -38,15 +41,15 @@ class Api::V1::HealthDataControllerTest < ActionDispatch::IntegrationTest
     assert json["workouts_count"] > 0
   end
 
-  test "creates a health_payload record" do
-    assert_difference "HealthPayload.count", 1 do
+  test "creates a health_payload record associated with user" do
+    assert_difference "@user.health_payloads.count", 1 do
       post api_v1_health_data_path,
         params: @payload,
         headers: {"Authorization" => "Bearer #{@token}"},
         as: :json
     end
 
-    assert_equal "processed", HealthPayload.last.status
+    assert_equal "processed", @user.health_payloads.last.status
   end
 
   test "returns 422 on malformed payload" do
@@ -56,6 +59,16 @@ class Api::V1::HealthDataControllerTest < ActionDispatch::IntegrationTest
       as: :json
 
     assert_response :unprocessable_entity
-    assert_equal "failed", HealthPayload.last.status
+    assert_equal "failed", @user.health_payloads.last.status
+  end
+
+  test "associates created workouts and metrics with user" do
+    post api_v1_health_data_path,
+      params: @payload,
+      headers: {"Authorization" => "Bearer #{@token}"},
+      as: :json
+
+    assert @user.workouts.count > 0
+    assert @user.health_metrics.count > 0
   end
 end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -5,15 +5,15 @@ class DashboardTest < ActionDispatch::IntegrationTest
     @user = users(:one)
     sign_in @user
 
-    HealthMetric.create!(metric_name: "weight", recorded_at: 1.hour.ago, value: 82.5, units: "kg")
-    HealthMetric.create!(metric_name: "resting_heart_rate", recorded_at: 1.hour.ago, value: 58, units: "bpm")
-    HealthMetric.create!(
+    @user.health_metrics.create!(metric_name: "weight", recorded_at: 1.hour.ago, value: 82.5, units: "kg")
+    @user.health_metrics.create!(metric_name: "resting_heart_rate", recorded_at: 1.hour.ago, value: 58, units: "bpm")
+    @user.health_metrics.create!(
       metric_name: "sleep_analysis", recorded_at: 1.hour.ago, value: 7.2, units: "hr",
       metadata: {"core" => 3.5, "deep" => 1.8, "rem" => 1.5,
                  "sleepStart" => "2026-03-13 22:45:00", "sleepEnd" => "2026-03-14 06:05:00",
                  "inBed" => 7.5}
     )
-    HealthPayload.create!(raw_json: {data: {}}, status: "processed")
+    @user.health_payloads.create!(raw_json: {data: {}}, status: "processed")
   end
 
   test "dashboard shows metric values" do
@@ -29,7 +29,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
   end
 
   test "dashboard shows today's workouts" do
-    Workout.create!(
+    @user.workouts.create!(
       external_id: "today-run", workout_type: "Running",
       started_at: 2.hours.ago, ended_at: 1.hour.ago, duration: 3600,
       distance: 10.0, distance_units: "km", energy_burned: 600

--- a/test/integration/workouts_test.rb
+++ b/test/integration/workouts_test.rb
@@ -5,13 +5,13 @@ class WorkoutsTest < ActionDispatch::IntegrationTest
     @user = users(:one)
     sign_in @user
 
-    @run = Workout.create!(
+    @run = @user.workouts.create!(
       external_id: "w-run", workout_type: "Outdoor Run",
       started_at: 2.days.ago, ended_at: 2.days.ago + 30.minutes,
       duration: 1800, distance: 5.0, distance_units: "km", energy_burned: 300,
       metadata: {"heartRate" => {"avg" => 155}}
     )
-    @swim = Workout.create!(
+    @swim = @user.workouts.create!(
       external_id: "w-swim", workout_type: "Pool Swim",
       started_at: 1.day.ago, ended_at: 1.day.ago + 40.minutes,
       duration: 2400, energy_burned: 400
@@ -70,5 +70,29 @@ class WorkoutsTest < ActionDispatch::IntegrationTest
     patch workout_path(@run), params: {workout: {notes: "test"}}
     assert_response :redirect
     assert_nil @run.reload.notes
+  end
+
+  test "cannot see other user's workouts" do
+    other_user = users(:two)
+    other_user.workouts.create!(
+      external_id: "other-run", workout_type: "Outdoor Run",
+      started_at: 1.day.ago, ended_at: 1.day.ago + 30.minutes,
+      duration: 1800
+    )
+    get workouts_path
+    assert_response :success
+    assert_no_match "other-run", response.body
+  end
+
+  test "cannot update other user's workout" do
+    other_user = users(:two)
+    other_workout = other_user.workouts.create!(
+      external_id: "other-edit", workout_type: "Running",
+      started_at: 1.day.ago, ended_at: 1.day.ago + 30.minutes,
+      duration: 1800
+    )
+    patch workout_path(other_workout), params: {workout: {notes: "hacked"}}
+    assert_response :not_found
+    assert_nil other_workout.reload.notes
   end
 end

--- a/test/models/health_metric_test.rb
+++ b/test/models/health_metric_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class HealthMetricTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
   test "valid with all required fields" do
-    metric = HealthMetric.new(
+    metric = @user.health_metrics.new(
       metric_name: "weight", recorded_at: Time.current,
       value: 82.5, units: "kg"
     )
@@ -10,14 +14,22 @@ class HealthMetricTest < ActiveSupport::TestCase
   end
 
   test "invalid without metric_name" do
-    metric = HealthMetric.new(recorded_at: Time.current, value: 82.5, units: "kg")
+    metric = @user.health_metrics.new(recorded_at: Time.current, value: 82.5, units: "kg")
     assert_not metric.valid?
   end
 
-  test "enforces uniqueness on metric_name and recorded_at" do
+  test "enforces uniqueness on user, metric_name, and recorded_at" do
     time = Time.current
-    HealthMetric.create!(metric_name: "weight", recorded_at: time, value: 82.5, units: "kg")
-    duplicate = HealthMetric.new(metric_name: "weight", recorded_at: time, value: 83.0, units: "kg")
+    @user.health_metrics.create!(metric_name: "weight", recorded_at: time, value: 82.5, units: "kg")
+    duplicate = @user.health_metrics.new(metric_name: "weight", recorded_at: time, value: 83.0, units: "kg")
     assert_not duplicate.valid?
+  end
+
+  test "allows same metric_name and recorded_at for different users" do
+    time = Time.current
+    other_user = users(:two)
+    @user.health_metrics.create!(metric_name: "weight", recorded_at: time, value: 82.5, units: "kg")
+    other_metric = other_user.health_metrics.new(metric_name: "weight", recorded_at: time, value: 75.0, units: "kg")
+    assert other_metric.valid?
   end
 end

--- a/test/models/health_payload_test.rb
+++ b/test/models/health_payload_test.rb
@@ -1,18 +1,22 @@
 require "test_helper"
 
 class HealthPayloadTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
   test "valid with raw_json and status" do
-    payload = HealthPayload.new(raw_json: {data: {}}, status: "pending")
+    payload = @user.health_payloads.new(raw_json: {data: {}}, status: "pending")
     assert payload.valid?
   end
 
   test "invalid without raw_json" do
-    payload = HealthPayload.new(raw_json: nil, status: "pending")
+    payload = @user.health_payloads.new(raw_json: nil, status: "pending")
     assert_not payload.valid?
   end
 
   test "invalid with unknown status" do
-    payload = HealthPayload.new(raw_json: {data: {}}, status: "unknown")
+    payload = @user.health_payloads.new(raw_json: {data: {}}, status: "unknown")
     assert_not payload.valid?
   end
 end

--- a/test/models/workout_test.rb
+++ b/test/models/workout_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class WorkoutTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
   test "valid with all required fields" do
-    workout = Workout.new(
+    workout = @user.workouts.new(
       external_id: "ABC-123", workout_type: "Running",
       started_at: 1.hour.ago, ended_at: Time.current,
       duration: 3600
@@ -11,18 +15,18 @@ class WorkoutTest < ActiveSupport::TestCase
   end
 
   test "invalid without external_id" do
-    workout = Workout.new(workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
+    workout = @user.workouts.new(workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
     assert_not workout.valid?
   end
 
   test "enforces uniqueness on external_id" do
-    Workout.create!(external_id: "ABC-123", workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
-    duplicate = Workout.new(external_id: "ABC-123", workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
+    @user.workouts.create!(external_id: "ABC-123", workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
+    duplicate = @user.workouts.new(external_id: "ABC-123", workout_type: "Running", started_at: 1.hour.ago, ended_at: Time.current, duration: 3600)
     assert_not duplicate.valid?
   end
 
   test "valid with blank notes" do
-    workout = Workout.new(
+    workout = @user.workouts.new(
       external_id: "NOTE-1", workout_type: "Running",
       started_at: 1.hour.ago, ended_at: Time.current,
       duration: 3600, notes: ""
@@ -31,7 +35,7 @@ class WorkoutTest < ActiveSupport::TestCase
   end
 
   test "valid with nil notes" do
-    workout = Workout.new(
+    workout = @user.workouts.new(
       external_id: "NOTE-2", workout_type: "Running",
       started_at: 1.hour.ago, ended_at: Time.current,
       duration: 3600, notes: nil
@@ -40,7 +44,7 @@ class WorkoutTest < ActiveSupport::TestCase
   end
 
   test "valid with notes within 280 characters" do
-    workout = Workout.new(
+    workout = @user.workouts.new(
       external_id: "NOTE-3", workout_type: "Running",
       started_at: 1.hour.ago, ended_at: Time.current,
       duration: 3600, notes: "Knee felt tight on hills"
@@ -49,7 +53,7 @@ class WorkoutTest < ActiveSupport::TestCase
   end
 
   test "invalid with notes exceeding 280 characters" do
-    workout = Workout.new(
+    workout = @user.workouts.new(
       external_id: "NOTE-4", workout_type: "Running",
       started_at: 1.hour.ago, ended_at: Time.current,
       duration: 3600, notes: "a" * 281

--- a/test/services/health_data_processor_test.rb
+++ b/test/services/health_data_processor_test.rb
@@ -2,12 +2,13 @@ require "test_helper"
 
 class HealthDataProcessorTest < ActiveSupport::TestCase
   setup do
+    @user = users(:one)
     raw_json = JSON.parse(File.read(Rails.root.join("docs/example_workout_payload.json")))
-    @payload = HealthPayload.create!(raw_json: raw_json, status: "pending")
+    @payload = @user.health_payloads.create!(raw_json: raw_json, status: "pending")
   end
 
   test "processes a valid payload end-to-end" do
-    result = HealthDataProcessor.call(@payload)
+    result = HealthDataProcessor.call(@payload, user: @user)
 
     assert result.success
     assert result.metrics_created > 0
@@ -17,7 +18,7 @@ class HealthDataProcessorTest < ActiveSupport::TestCase
 
   test "marks payload as failed on error" do
     @payload.update!(raw_json: {"data" => {"metrics" => "not_an_array"}})
-    result = HealthDataProcessor.call(@payload)
+    result = HealthDataProcessor.call(@payload, user: @user)
 
     assert_not result.success
     assert_equal "failed", @payload.reload.status
@@ -26,15 +27,15 @@ class HealthDataProcessorTest < ActiveSupport::TestCase
 
   test "rolls back all records on partial failure" do
     @payload.update!(raw_json: {"data" => {"metrics" => [], "workouts" => "bad"}})
-    HealthDataProcessor.call(@payload)
+    HealthDataProcessor.call(@payload, user: @user)
 
-    assert_equal 0, HealthMetric.count
-    assert_equal 0, Workout.count
+    assert_equal 0, @user.health_metrics.count
+    assert_equal 0, @user.workouts.count
   end
 
   test "handles payload with only metrics (no workouts key)" do
     @payload.update!(raw_json: {"data" => {"metrics" => @payload.raw_json.dig("data", "metrics")}})
-    result = HealthDataProcessor.call(@payload)
+    result = HealthDataProcessor.call(@payload, user: @user)
 
     assert result.success
     assert result.metrics_created > 0

--- a/test/services/health_data_reprocessor_test.rb
+++ b/test/services/health_data_reprocessor_test.rb
@@ -1,9 +1,13 @@
 require "test_helper"
 
 class HealthDataReprocessorTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
   test "deduplicates overlapping payloads — latest wins" do
     # First payload: partial day
-    HealthPayload.create!(raw_json: {
+    @user.health_payloads.create!(raw_json: {
       "data" => {"metrics" => [
         {"name" => "step_count", "units" => "count", "data" => [
           {"qty" => 5000, "date" => "2026-03-14 00:00:00 -0800"}
@@ -12,7 +16,7 @@ class HealthDataReprocessorTest < ActiveSupport::TestCase
     })
 
     # Second payload: same day, updated total (latest wins)
-    HealthPayload.create!(raw_json: {
+    @user.health_payloads.create!(raw_json: {
       "data" => {"metrics" => [
         {"name" => "step_count", "units" => "count", "data" => [
           {"qty" => 12000, "date" => "2026-03-14 00:00:00 -0800"}
@@ -22,19 +26,19 @@ class HealthDataReprocessorTest < ActiveSupport::TestCase
 
     HealthDataReprocessor.call
 
-    assert_equal 1, HealthMetric.where(metric_name: "step_count").count
-    assert_equal 12000, HealthMetric.find_by(metric_name: "step_count").value
+    assert_equal 1, @user.health_metrics.where(metric_name: "step_count").count
+    assert_equal 12000, @user.health_metrics.find_by(metric_name: "step_count").value
   end
 
   test "deduplicates workouts by external_id across payloads" do
-    HealthPayload.create!(raw_json: {
+    @user.health_payloads.create!(raw_json: {
       "data" => {"workouts" => [
         {"id" => "ABC-123", "name" => "Running", "start" => "2026-03-14 07:00:00 -0800",
          "end" => "2026-03-14 08:00:00 -0800", "duration" => 3600}
       ]}
     })
 
-    HealthPayload.create!(raw_json: {
+    @user.health_payloads.create!(raw_json: {
       "data" => {"workouts" => [
         {"id" => "ABC-123", "name" => "Running", "start" => "2026-03-14 07:00:00 -0800",
          "end" => "2026-03-14 08:00:00 -0800", "duration" => 3600}
@@ -43,16 +47,42 @@ class HealthDataReprocessorTest < ActiveSupport::TestCase
 
     HealthDataReprocessor.call
 
-    assert_equal 1, Workout.count
+    assert_equal 1, @user.workouts.count
   end
 
   test "marks all payloads as processed" do
-    HealthPayload.create!(raw_json: {"data" => {"metrics" => []}}, status: "failed", error_message: "old error")
-    HealthPayload.create!(raw_json: {"data" => {"metrics" => []}}, status: "pending")
+    @user.health_payloads.create!(raw_json: {"data" => {"metrics" => []}}, status: "failed", error_message: "old error")
+    @user.health_payloads.create!(raw_json: {"data" => {"metrics" => []}}, status: "pending")
 
     HealthDataReprocessor.call
 
     assert HealthPayload.where.not(status: "processed").none?
     assert HealthPayload.where.not(error_message: nil).none?
+  end
+
+  test "scopes deletes to the user — does not affect other users" do
+    other_user = users(:two)
+
+    @user.health_payloads.create!(raw_json: {
+      "data" => {"metrics" => [
+        {"name" => "step_count", "units" => "count", "data" => [
+          {"qty" => 8000, "date" => "2026-03-14 00:00:00 -0800"}
+        ]}
+      ]}
+    })
+
+    other_user.workouts.create!(
+      external_id: "other-run", workout_type: "Running",
+      started_at: 1.day.ago, ended_at: 1.day.ago + 30.minutes, duration: 1800
+    )
+    other_user.health_metrics.create!(
+      metric_name: "weight", recorded_at: 1.day.ago, value: 75.0, units: "kg"
+    )
+
+    HealthDataReprocessor.call
+
+    # Other user's data should be untouched
+    assert_equal 1, other_user.workouts.count
+    assert_equal 1, other_user.health_metrics.count
   end
 end

--- a/test/services/metrics_parser_test.rb
+++ b/test/services/metrics_parser_test.rb
@@ -2,25 +2,26 @@ require "test_helper"
 
 class MetricsParserTest < ActiveSupport::TestCase
   setup do
+    @user = users(:one)
     payload_json = JSON.parse(File.read(Rails.root.join("docs/example_workout_payload.json")))
     @metrics_data = payload_json.dig("data", "metrics")
   end
 
   test "parses simple qty metrics (weight)" do
     weight_data = @metrics_data.find { |m| m["name"] == "weight" }
-    result = MetricsParser.call([weight_data])
+    result = MetricsParser.call([weight_data], user: @user)
 
     assert_equal 1, result.created
-    metric = HealthMetric.find_by(metric_name: "weight")
+    metric = @user.health_metrics.find_by(metric_name: "weight")
     assert_equal 82.5, metric.value
     assert_equal "kg", metric.units
   end
 
   test "parses sleep_analysis with metadata" do
     sleep_data = @metrics_data.find { |m| m["name"] == "sleep_analysis" }
-    MetricsParser.call([sleep_data])
+    MetricsParser.call([sleep_data], user: @user)
 
-    metric = HealthMetric.find_by(metric_name: "sleep_analysis")
+    metric = @user.health_metrics.find_by(metric_name: "sleep_analysis")
     assert_equal 7.2, metric.value
     assert_equal "hr", metric.units
     assert_equal 1.8, metric.metadata["deep"]
@@ -29,11 +30,11 @@ class MetricsParserTest < ActiveSupport::TestCase
 
   test "parses heart_rate with min/max/avg metadata" do
     hr_data = @metrics_data.find { |m| m["name"] == "heart_rate" }
-    MetricsParser.call([hr_data])
+    MetricsParser.call([hr_data], user: @user)
 
     # Example payload has 3 HR readings — each stored as its own row
-    assert_equal 3, HealthMetric.where(metric_name: "heart_rate").count
-    metric = HealthMetric.where(metric_name: "heart_rate").order(:recorded_at).first
+    assert_equal 3, @user.health_metrics.where(metric_name: "heart_rate").count
+    metric = @user.health_metrics.where(metric_name: "heart_rate").order(:recorded_at).first
     assert_equal 58, metric.value
     assert_equal 55, metric.metadata["min"]
     assert_equal 62, metric.metadata["max"]
@@ -42,24 +43,24 @@ class MetricsParserTest < ActiveSupport::TestCase
   test "replaces existing metric on same day" do
     weight_data = [{"name" => "step_count", "units" => "count",
                     "data" => [{"qty" => 5000, "date" => "2026-03-14 00:00:00 -0800"}]}]
-    MetricsParser.call(weight_data)
+    MetricsParser.call(weight_data, user: @user)
 
     updated_data = [{"name" => "step_count", "units" => "count",
                      "data" => [{"qty" => 12000, "date" => "2026-03-14 00:00:00 -0800"}]}]
-    result = MetricsParser.call(updated_data)
+    result = MetricsParser.call(updated_data, user: @user)
 
     assert_equal 0, result.created
     assert_equal 1, result.updated
-    assert_equal 1, HealthMetric.where(metric_name: "step_count").count
-    assert_equal 12000, HealthMetric.find_by(metric_name: "step_count").value
+    assert_equal 1, @user.health_metrics.where(metric_name: "step_count").count
+    assert_equal 12000, @user.health_metrics.find_by(metric_name: "step_count").value
   end
 
   test "converts active_energy from kJ to kcal" do
     kj_data = [{"name" => "active_energy", "units" => "kJ",
                 "data" => [{"qty" => 4184.0, "date" => "2026-03-14 00:00:00 -0800"}]}]
-    MetricsParser.call(kj_data)
+    MetricsParser.call(kj_data, user: @user)
 
-    metric = HealthMetric.find_by(metric_name: "active_energy")
+    metric = @user.health_metrics.find_by(metric_name: "active_energy")
     assert_equal "kcal", metric.units
     assert_in_delta 1000.0, metric.value, 0.1
   end
@@ -67,25 +68,25 @@ class MetricsParserTest < ActiveSupport::TestCase
   test "normalizes weight_body_mass to weight" do
     data = [{"name" => "weight_body_mass", "units" => "kg",
              "data" => [{"qty" => 70.5, "date" => "2026-03-14 00:00:00 -0800"}]}]
-    result = MetricsParser.call(data)
+    result = MetricsParser.call(data, user: @user)
 
     assert_equal 1, result.created
-    metric = HealthMetric.find_by(metric_name: "weight")
+    metric = @user.health_metrics.find_by(metric_name: "weight")
     assert_equal 70.5, metric.value
-    assert_nil HealthMetric.find_by(metric_name: "weight_body_mass")
+    assert_nil @user.health_metrics.find_by(metric_name: "weight_body_mass")
   end
 
   test "ignores excluded metrics" do
     ignored = [{"name" => "time_in_daylight", "units" => "min",
                 "data" => [{"qty" => 30, "date" => "2026-03-14 00:00:00 -0800"}]}]
-    result = MetricsParser.call(ignored)
+    result = MetricsParser.call(ignored, user: @user)
 
     assert_equal 0, result.created
-    assert_equal 0, HealthMetric.count
+    assert_equal 0, @user.health_metrics.count
   end
 
   test "parses all metrics from example payload" do
-    result = MetricsParser.call(@metrics_data)
+    result = MetricsParser.call(@metrics_data, user: @user)
 
     assert result.created > 0
   end

--- a/test/services/plan_adherence_generator_test.rb
+++ b/test/services/plan_adherence_generator_test.rb
@@ -28,7 +28,7 @@ class PlanAdherenceGeneratorTest < ActiveSupport::TestCase
   end
 
   test "includes plan content and workout data in the context" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "adherence-test",
       workout_type: "Running",
       started_at: 2.days.ago,
@@ -50,7 +50,7 @@ class PlanAdherenceGeneratorTest < ActiveSupport::TestCase
   end
 
   test "includes workout notes in the context when present" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "adherence-noted",
       workout_type: "Running",
       started_at: 2.days.ago,

--- a/test/services/plan_suggestion_generator_test.rb
+++ b/test/services/plan_suggestion_generator_test.rb
@@ -41,7 +41,7 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
   end
 
   test "includes recent workouts in the context" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "test-workout-suggestion",
       workout_type: "Running",
       started_at: 2.days.ago,
@@ -63,7 +63,7 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
   end
 
   test "includes today's completed workouts in the context" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "today-strength",
       workout_type: "Traditional Strength Training",
       started_at: 3.hours.ago,
@@ -83,7 +83,7 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
   end
 
   test "includes workout notes in the context when present" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "noted-workout",
       workout_type: "Running",
       started_at: 2.days.ago,
@@ -102,7 +102,7 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
   end
 
   test "includes today's workout notes in the context" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "today-noted",
       workout_type: "Running",
       started_at: 1.hour.ago,
@@ -121,7 +121,7 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
   end
 
   test "omits notes from context when not present" do
-    Workout.create!(
+    @plan.user.workouts.create!(
       external_id: "no-note-workout",
       workout_type: "Running",
       started_at: 2.days.ago,

--- a/test/services/workout_parser_test.rb
+++ b/test/services/workout_parser_test.rb
@@ -2,15 +2,16 @@ require "test_helper"
 
 class WorkoutParserTest < ActiveSupport::TestCase
   setup do
+    @user = users(:one)
     payload_json = JSON.parse(File.read(Rails.root.join("docs/example_workout_payload.json")))
     @workouts_data = payload_json.dig("data", "workouts")
   end
 
   test "parses a running workout with common fields" do
-    result = WorkoutParser.call(@workouts_data)
+    result = WorkoutParser.call(@workouts_data, user: @user)
 
     assert_equal 1, result.created
-    workout = Workout.find_by(external_id: "F4A3B2C1-1234-5678-9ABC-DEF012345678")
+    workout = @user.workouts.find_by(external_id: "F4A3B2C1-1234-5678-9ABC-DEF012345678")
     assert_equal "Running", workout.workout_type
     assert_equal 2700, workout.duration
     assert_in_delta 8.04, workout.distance
@@ -19,8 +20,8 @@ class WorkoutParserTest < ActiveSupport::TestCase
   end
 
   test "stores time-series and route data in metadata" do
-    WorkoutParser.call(@workouts_data)
-    workout = Workout.first
+    WorkoutParser.call(@workouts_data, user: @user)
+    workout = @user.workouts.first
 
     assert workout.metadata["heartRateData"].is_a?(Array)
     assert workout.metadata["route"].is_a?(Array)
@@ -29,8 +30,8 @@ class WorkoutParserTest < ActiveSupport::TestCase
   end
 
   test "stores heart rate summary in metadata" do
-    WorkoutParser.call(@workouts_data)
-    workout = Workout.first
+    WorkoutParser.call(@workouts_data, user: @user)
+    workout = @user.workouts.first
 
     assert_equal 155, workout.metadata.dig("heartRate", "avg")
     assert_equal 178, workout.metadata.dig("heartRate", "max")
@@ -39,18 +40,18 @@ class WorkoutParserTest < ActiveSupport::TestCase
 
   test "converts energy_burned from kJ to kcal" do
     @workouts_data.first["activeEnergyBurned"] = {"qty" => 2030.3, "units" => "kJ"}
-    WorkoutParser.call(@workouts_data)
+    WorkoutParser.call(@workouts_data, user: @user)
 
-    workout = Workout.first
+    workout = @user.workouts.first
     assert_in_delta 485.5, workout.energy_burned, 0.5
   end
 
   test "deduplicates on external_id" do
-    WorkoutParser.call(@workouts_data)
-    result = WorkoutParser.call(@workouts_data)
+    WorkoutParser.call(@workouts_data, user: @user)
+    result = WorkoutParser.call(@workouts_data, user: @user)
 
     assert_equal 0, result.created
     assert_equal 1, result.skipped
-    assert_equal 1, Workout.count
+    assert_equal 1, @user.workouts.count
   end
 end


### PR DESCRIPTION
## Summary
- Add `user_id` FK to `workouts`, `health_metrics`, and `health_payloads` tables with backfill migration
- Scope all controller queries, LLM generators, service objects, and CSV importer through user associations
- Webhook API associates incoming data with `jules@julescoleman.com` (per-user tokens deferred)

## Test plan
- [x] 102 tests pass (0 failures)
- [x] Brakeman: 0 security warnings
- [x] Cross-user isolation tests: user A cannot see or edit user B's workouts
- [x] HealthDataReprocessor scopes deletes per-user
- [ ] Verify dashboard and workouts pages in production after deploy
- [ ] Verify webhook ingestion still works with existing iOS Shortcut

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)