### PR TITLE
feat: async LLM estimation for snappier food logging

### DIFF
--- a/app/controllers/food_logs_controller.rb
+++ b/app/controllers/food_logs_controller.rb
@@ -17,27 +17,22 @@ class FoodLogsController < ApplicationController
   end
 
   def create
-    result = FoodEstimationService.call(params[:description])
-
-    unless result.success
-      redirect_to new_food_log_path, alert: "Could not estimate macros — please try again."
-      return
-    end
-
     food = current_user.foods.create!(
       description: params[:description],
-      **result.macros.symbolize_keys
+      kcal: 0, protein: 0, carbs: 0, fat: 0, fibre: 0, alcohol: 0
     )
 
-    log = current_user.food_logs.new(
+    log = current_user.food_logs.create!(
       food: food,
       consumed_at: build_consumed_at,
-      mealtime: params[:mealtime]
+      mealtime: params[:mealtime],
+      estimated: false,
+      kcal: 0, protein: 0, carbs: 0, fat: 0, fibre: 0, alcohol: 0
     )
-    log.stamp_macros_from_food!
-    log.save!
 
-    redirect_to food_logs_path(date: log.consumed_at.to_date), notice: "#{food.description} logged."
+    FoodEstimationJob.perform_later(log.id)
+
+    redirect_to food_logs_path(date: log.consumed_at.to_date), notice: "#{food.description} logged — estimating macros..."
   end
 
   def quick_add

--- a/app/javascript/controllers/auto_refresh_controller.js
+++ b/app/javascript/controllers/auto_refresh_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Auto-refreshes the page while there are pending estimates.
+// Usage: data-controller="auto-refresh" on a container element.
+// Refreshes every 2 seconds until the element is removed from the DOM
+// (i.e., all estimates are complete and the page no longer renders this controller).
+export default class extends Controller {
+  connect() {
+    this.timer = setTimeout(() => {
+      window.location.reload()
+    }, 2000)
+  }
+
+  disconnect() {
+    if (this.timer) clearTimeout(this.timer)
+  }
+}

--- a/app/jobs/food_estimation_job.rb
+++ b/app/jobs/food_estimation_job.rb
@@ -1,0 +1,17 @@
+class FoodEstimationJob < ApplicationJob
+  def perform(food_log_id)
+    food_log = FoodLog.find(food_log_id)
+    food = food_log.food
+
+    result = FoodEstimationService.call(food.description)
+
+    if result.success
+      macros = result.macros.symbolize_keys
+      food.update!(macros)
+      food_log.update!(estimated: true, **macros)
+    else
+      Rails.logger.error("FoodEstimationJob failed for FoodLog##{food_log_id}: #{result.error}")
+      food_log.update!(estimated: true)
+    end
+  end
+end

--- a/app/views/food_logs/index.html.erb
+++ b/app/views/food_logs/index.html.erb
@@ -65,10 +65,14 @@
                 <div class="flex items-center justify-between">
                   <p class="text-sm text-zinc-100 truncate flex-1 mr-3"><%= log.food.description %></p>
                   <div class="text-right shrink-0">
-                    <span class="text-sm font-medium text-zinc-100"><%= log.kcal.to_i %></span>
-                    <span class="text-xs text-zinc-500">kcal</span>
-                    <span class="text-xs text-zinc-400 ml-2"><%= log.protein.to_i %>g P</span>
-                    <span class="text-xs text-zinc-400 ml-1"><%= log.net_carbs.to_i %>g NC</span>
+                    <% if log.estimated? %>
+                      <span class="text-sm font-medium text-zinc-100"><%= log.kcal.to_i %></span>
+                      <span class="text-xs text-zinc-500">kcal</span>
+                      <span class="text-xs text-zinc-400 ml-2"><%= log.protein.to_i %>g P</span>
+                      <span class="text-xs text-zinc-400 ml-1"><%= log.net_carbs.to_i %>g NC</span>
+                    <% else %>
+                      <span class="text-xs text-zinc-400 italic">Estimating...</span>
+                    <% end %>
                   </div>
                 </div>
               <% end %>
@@ -83,6 +87,10 @@
           </div>
         </div>
       </section>
+    <% end %>
+
+    <% if @food_logs.any? { |l| !l.estimated? } %>
+      <div data-controller="auto-refresh"></div>
     <% end %>
 
     <% if @food_logs.empty? %>

--- a/db/migrate/20260330032748_add_estimated_to_food_logs.rb
+++ b/db/migrate/20260330032748_add_estimated_to_food_logs.rb
@@ -1,0 +1,5 @@
+class AddEstimatedToFoodLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :food_logs, :estimated, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_30_020024) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_30_032748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_30_020024) do
     t.decimal "carbs", precision: 5, scale: 1
     t.datetime "consumed_at", null: false
     t.datetime "created_at", null: false
+    t.boolean "estimated", default: true, null: false
     t.decimal "fat", precision: 5, scale: 1
     t.decimal "fibre", precision: 5, scale: 1
     t.bigint "food_id", null: false

--- a/test/integration/food_logs_test.rb
+++ b/test/integration/food_logs_test.rb
@@ -27,36 +27,26 @@ class FoodLogsTest < ActionDispatch::IntegrationTest
     assert_match "Eggs on toast", response.body
   end
 
-  # -- create (LLM estimation) --
+  # -- create (async LLM estimation) --
 
-  test "create estimates macros and saves food log" do
-    llm_response = '{"kcal": 300, "protein": 25.0, "carbs": 20.0, "fat": 12.0, "fibre": 2.0, "alcohol": 0.0}'
-
-    stub_llm_chat(llm_response) do
-      assert_difference ["Food.count", "FoodLog.count"], 1 do
+  test "create saves food log immediately and enqueues estimation job" do
+    assert_difference ["Food.count", "FoodLog.count"], 1 do
+      assert_enqueued_with(job: FoodEstimationJob) do
         post food_logs_path, params: {description: "Grilled chicken wrap", mealtime: "lunch", consumed_at_hour: 13}
       end
     end
 
     log = @user.food_logs.last
     assert_redirected_to food_logs_path(date: log.consumed_at.to_date)
-    follow_redirect!
-    assert_match "Grilled chicken wrap logged", response.body
     assert_equal "lunch", log.mealtime
-    assert_equal 300.0, log.kcal.to_f
-    assert_equal 25.0, log.protein.to_f
+    assert_equal false, log.estimated?
+    assert_equal 0, log.kcal.to_i
   end
 
-  test "create shows error on LLM failure" do
-    stub_llm_chat_error("API timeout") do
-      assert_no_difference ["Food.count", "FoodLog.count"] do
-        post food_logs_path, params: {description: "Mystery food", mealtime: "dinner"}
-      end
-    end
-
-    assert_redirected_to new_food_log_path
+  test "create redirects to daily view with estimating notice" do
+    post food_logs_path, params: {description: "Grilled chicken wrap", mealtime: "lunch"}
     follow_redirect!
-    assert_match "Could not estimate", response.body
+    assert_match "estimating macros", response.body
   end
 
   # -- quick_add --
@@ -154,28 +144,5 @@ class FoodLogsTest < ActionDispatch::IntegrationTest
     sign_out @user
     get new_food_log_path
     assert_response :redirect
-  end
-
-  private
-
-  def stub_llm_chat(response_text)
-    fake_response = Data.define(:content).new(content: response_text)
-    fake_chat = Object.new
-    fake_chat.define_singleton_method(:with_instructions) { |_| self }
-    fake_chat.define_singleton_method(:ask) { |_| fake_response }
-
-    original_chat = RubyLLM.method(:chat)
-    RubyLLM.define_singleton_method(:chat) { |**_| fake_chat }
-    yield
-  ensure
-    RubyLLM.define_singleton_method(:chat, original_chat)
-  end
-
-  def stub_llm_chat_error(message)
-    original_chat = RubyLLM.method(:chat)
-    RubyLLM.define_singleton_method(:chat) { |**_| raise message }
-    yield
-  ensure
-    RubyLLM.define_singleton_method(:chat, original_chat)
   end
 end

--- a/test/jobs/food_estimation_job_test.rb
+++ b/test/jobs/food_estimation_job_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class FoodEstimationJobTest < ActiveSupport::TestCase
+  setup do
+    @food = foods(:eggs_on_toast)
+    @log = food_logs(:breakfast_eggs)
+    @log.update!(estimated: false, kcal: 0, protein: 0, carbs: 0, fat: 0, fibre: 0, alcohol: 0)
+  end
+
+  test "updates food and food_log with estimated macros" do
+    llm_response = '{"kcal": 350, "protein": 20.0, "carbs": 30.0, "fat": 18.0, "fibre": 2.0, "alcohol": 0.0}'
+
+    stub_llm_chat(llm_response) do
+      FoodEstimationJob.perform_now(@log.id)
+    end
+
+    @log.reload
+    assert @log.estimated?
+    assert_equal 350.0, @log.kcal.to_f
+    assert_equal 20.0, @log.protein.to_f
+
+    @food.reload
+    assert_equal 350.0, @food.kcal.to_f
+    assert_equal 20.0, @food.protein.to_f
+  end
+
+  test "marks as estimated even on LLM failure" do
+    stub_llm_chat_error("API timeout") do
+      FoodEstimationJob.perform_now(@log.id)
+    end
+
+    @log.reload
+    assert @log.estimated?
+    assert_equal 0, @log.kcal.to_i
+  end
+
+  private
+
+  def stub_llm_chat(response_text)
+    fake_response = Data.define(:content).new(content: response_text)
+    fake_chat = Object.new
+    fake_chat.define_singleton_method(:with_instructions) { |_| self }
+    fake_chat.define_singleton_method(:ask) { |_| fake_response }
+
+    original_chat = RubyLLM.method(:chat)
+    RubyLLM.define_singleton_method(:chat) { |**_| fake_chat }
+    yield
+  ensure
+    RubyLLM.define_singleton_method(:chat, original_chat)
+  end
+
+  def stub_llm_chat_error(message)
+    original_chat = RubyLLM.method(:chat)
+    RubyLLM.define_singleton_method(:chat) { |**_| raise message }
+    yield
+  ensure
+    RubyLLM.define_singleton_method(:chat, original_chat)
+  end
+end


### PR DESCRIPTION
Save food log immediately with zero macros, enqueue FoodEstimationJob to estimate in background. Daily view shows "Estimating..." for pending entries and auto-refreshes every 2s until all estimates complete.