### PR TITLE
Notion training sync: auto-populate daily logs, workouts, and weekly reviews from Apple Health

### DIFF
--- a/app/controllers/api/v1/health_data_controller.rb
+++ b/app/controllers/api/v1/health_data_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::HealthDataController < ActionController::API
     result = HealthDataProcessor.call(health_payload, user: user)
 
     if result.success
+      NotionSyncJob.perform_later
       render json: {
         status: "ok",
         metrics_count: result.metrics_created,

--- a/app/jobs/daily_log_commentary_job.rb
+++ b/app/jobs/daily_log_commentary_job.rb
@@ -1,0 +1,10 @@
+class DailyLogCommentaryJob < ApplicationJob
+  def perform
+    user = User.find_by!(email: "jules@julescoleman.com")
+    date = Notion::TrainingWeek.today
+    result = Notion::DailyLogCommentaryGenerator.call(user, date: date)
+    unless result.success
+      Rails.logger.error("DailyLogCommentaryJob failed for #{date}: #{result.error}")
+    end
+  end
+end

--- a/app/jobs/notion_sync_job.rb
+++ b/app/jobs/notion_sync_job.rb
@@ -1,0 +1,17 @@
+class NotionSyncJob < ApplicationJob
+  limits_concurrency to: 1, key: "notion_sync"
+
+  def perform
+    user = User.find_by!(email: "jules@julescoleman.com")
+    client = Notion::Client.new
+    today = Notion::TrainingWeek.today
+
+    [today - 1, today].each do |date|
+      workout_result = Notion::WorkoutSync.call(user, date: date, client: client)
+      Notion::DailyLogSync.call(user, date: date, day_type: workout_result.day_type, client: client)
+      workout_result.newly_synced_workout_ids.each do |workout_id|
+        WorkoutCommentaryJob.perform_later(workout_id)
+      end
+    end
+  end
+end

--- a/app/jobs/notion_sync_job.rb
+++ b/app/jobs/notion_sync_job.rb
@@ -5,13 +5,20 @@ class NotionSyncJob < ApplicationJob
     user = User.find_by!(email: "jules@julescoleman.com")
     client = Notion::Client.new
     today = Notion::TrainingWeek.today
+    errors = []
 
     [today - 1, today].each do |date|
       workout_result = Notion::WorkoutSync.call(user, date: date, client: client)
-      Notion::DailyLogSync.call(user, date: date, day_type: workout_result.day_type, client: client)
+      errors << "WorkoutSync(#{date}): #{workout_result.error}" unless workout_result.success
+
+      daily_result = Notion::DailyLogSync.call(user, date: date, day_type: workout_result.day_type, client: client)
+      errors << "DailyLogSync(#{date}): #{daily_result.error}" unless daily_result.success
+
       workout_result.newly_synced_workout_ids.each do |workout_id|
         WorkoutCommentaryJob.perform_later(workout_id)
       end
     end
+
+    raise "NotionSyncJob partial failure: #{errors.join("; ")}" if errors.any?
   end
 end

--- a/app/jobs/notion_sync_job.rb
+++ b/app/jobs/notion_sync_job.rb
@@ -1,5 +1,6 @@
 class NotionSyncJob < ApplicationJob
   limits_concurrency to: 1, key: "notion_sync"
+  retry_on Notion::Client::Error, wait: :polynomially_longer, attempts: 3
 
   def perform
     user = User.find_by!(email: "jules@julescoleman.com")
@@ -19,6 +20,6 @@ class NotionSyncJob < ApplicationJob
       end
     end
 
-    raise "NotionSyncJob partial failure: #{errors.join("; ")}" if errors.any?
+    raise Notion::Client::Error, "NotionSyncJob partial failure: #{errors.join("; ")}" if errors.any?
   end
 end

--- a/app/jobs/weekly_review_job.rb
+++ b/app/jobs/weekly_review_job.rb
@@ -1,0 +1,10 @@
+class WeeklyReviewJob < ApplicationJob
+  def perform
+    user = User.find_by!(email: "jules@julescoleman.com")
+    date = Notion::TrainingWeek.today
+    result = Notion::WeeklyReviewGenerator.call(user, date: date)
+    unless result.success
+      Rails.logger.error("WeeklyReviewJob failed for #{date}: #{result.error}")
+    end
+  end
+end

--- a/app/jobs/workout_commentary_job.rb
+++ b/app/jobs/workout_commentary_job.rb
@@ -1,0 +1,5 @@
+class WorkoutCommentaryJob < ApplicationJob
+  def perform(workout_id)
+    # implemented in Task 8
+  end
+end

--- a/app/jobs/workout_commentary_job.rb
+++ b/app/jobs/workout_commentary_job.rb
@@ -1,5 +1,9 @@
 class WorkoutCommentaryJob < ApplicationJob
   def perform(workout_id)
-    # implemented in Task 8
+    workout = Workout.find(workout_id)
+    result = Notion::WorkoutCommentaryGenerator.call(workout)
+    unless result.success
+      Rails.logger.error("WorkoutCommentaryJob failed for Workout##{workout_id}: #{result.error}")
+    end
   end
 end

--- a/app/services/notion/client.rb
+++ b/app/services/notion/client.rb
@@ -54,12 +54,16 @@ module Notion
       req["Content-Type"] = "application/json"
       req.body = JSON.generate(body)
 
-      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
-      parsed = JSON.parse(response.body)
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 30) { |http| http.request(req) }
       unless response.is_a?(Net::HTTPSuccess)
-        raise Error, "Notion API #{response.code} on #{method.to_s.upcase} #{path}: #{parsed["message"]}"
+        message = begin
+          JSON.parse(response.body)["message"]
+        rescue JSON::ParserError
+          response.body.to_s[0, 200]
+        end
+        raise Error, "Notion API #{response.code} on #{method.to_s.upcase} #{path}: #{message}"
       end
-      parsed
+      JSON.parse(response.body)
     end
   end
 end

--- a/app/services/notion/client.rb
+++ b/app/services/notion/client.rb
@@ -1,0 +1,65 @@
+require "net/http"
+
+module Notion
+  class Client
+    Error = Class.new(StandardError)
+
+    BASE_URL = "https://api.notion.com/v1"
+    API_VERSION = "2025-09-03"
+
+    def initialize(token: ENV.fetch("NOTION_API_TOKEN"))
+      @token = token
+    end
+
+    def query_data_source(data_source_id, filter: nil)
+      results = []
+      cursor = nil
+      loop do
+        body = {}
+        body["filter"] = filter if filter
+        body["start_cursor"] = cursor if cursor
+        response = request(:post, "/data_sources/#{data_source_id}/query", body)
+        results.concat(response["results"])
+        break unless response["has_more"]
+        cursor = response["next_cursor"]
+      end
+      results
+    end
+
+    def create_page(data_source_id:, properties:, children: nil)
+      body = {
+        "parent" => {"type" => "data_source_id", "data_source_id" => data_source_id},
+        "properties" => properties
+      }
+      body["children"] = children if children
+      request(:post, "/pages", body)
+    end
+
+    def update_page(page_id, properties:)
+      request(:patch, "/pages/#{page_id}", {"properties" => properties})
+    end
+
+    def append_blocks(page_id, children:)
+      request(:patch, "/blocks/#{page_id}/children", {"children" => children})
+    end
+
+    private
+
+    def request(method, path, body)
+      uri = URI("#{BASE_URL}#{path}")
+      request_class = (method == :post) ? Net::HTTP::Post : Net::HTTP::Patch
+      req = request_class.new(uri)
+      req["Authorization"] = "Bearer #{@token}"
+      req["Notion-Version"] = API_VERSION
+      req["Content-Type"] = "application/json"
+      req.body = JSON.generate(body)
+
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+      parsed = JSON.parse(response.body)
+      unless response.is_a?(Net::HTTPSuccess)
+        raise Error, "Notion API #{response.code} on #{method.to_s.upcase} #{path}: #{parsed["message"]}"
+      end
+      parsed
+    end
+  end
+end

--- a/app/services/notion/daily_log_commentary_generator.rb
+++ b/app/services/notion/daily_log_commentary_generator.rb
@@ -51,7 +51,8 @@ module Notion
       page = query_page
       return page if page
 
-      DailyLogSync.call(@user, date: @date, client: @client)
+      result = DailyLogSync.call(@user, date: @date, client: @client)
+      Rails.logger.error("Notion::DailyLogCommentaryGenerator: DailyLogSync failed creating page for #{@date}: #{result.error}") unless result.success
       query_page
     end
 

--- a/app/services/notion/daily_log_commentary_generator.rb
+++ b/app/services/notion/daily_log_commentary_generator.rb
@@ -1,0 +1,152 @@
+module Notion
+  class DailyLogCommentaryGenerator
+    Result = Struct.new(:success, :narrative, :flags, :error, keyword_init: true)
+
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a concise daily training coach reviewing one athlete's full day of data.
+      Given the day's health metrics, nutrition, workouts, training plan, and yesterday's
+      comparison, write one paragraph of narrative commentary: how the day went overall,
+      notable signals (sleep, HRV, RHR, nutrition, training load), and what to watch for
+      tomorrow. No headers, no bullet points. Be direct and data-specific.
+    PROMPT
+
+    def self.call(user, date:, client: Client.new)
+      new(user, date: date, client: client).call
+    end
+
+    def initialize(user, date:, client:)
+      @user = user
+      @date = date
+      @client = client
+    end
+
+    def call
+      page = find_or_create_page
+      return Result.new(success: false, error: "could not find or create daily log page") unless page
+
+      page_id = page["id"]
+      existing_flags = Properties.read_multi_select(page.dig("properties", "Red Flags"))
+
+      narrative = generate_narrative
+      return Result.new(success: false, error: narrative[:error]) if narrative[:error]
+
+      computed_flags = RedFlagDetector.call(@user, date: @date)
+      merged_flags = (existing_flags | computed_flags).sort
+
+      properties = {"Notes" => Properties.rich_text(narrative[:text])}
+      properties["Red Flags"] = Properties.multi_select(merged_flags) if merged_flags != existing_flags.sort
+
+      @client.update_page(page_id, properties: properties)
+      Result.new(success: true, narrative: narrative[:text], flags: merged_flags)
+    rescue => e
+      Rails.logger.error("Notion::DailyLogCommentaryGenerator failed for #{@date}: #{e.class}: #{e.message}")
+      Result.new(success: false, error: e.message)
+    end
+
+    private
+
+    def ds_id = ENV.fetch("NOTION_DAILY_LOGS_DS_ID")
+
+    def find_or_create_page
+      page = query_page
+      return page if page
+
+      DailyLogSync.call(@user, date: @date, client: @client)
+      query_page
+    end
+
+    def query_page
+      @client.query_data_source(ds_id,
+        filter: {"property" => "Date", "date" => {"equals" => @date.iso8601}}).first
+    end
+
+    def generate_narrative
+      response = RubyLLM.chat(model: ENV.fetch("LLM_MODEL", "gpt-5-nano"))
+        .with_params(reasoning_effort: "medium")
+        .with_instructions(SYSTEM_PROMPT)
+        .ask(build_context)
+      {text: response.content}
+    rescue => e
+      Rails.logger.error("Notion::DailyLogCommentaryGenerator LLM failed for #{@date}: #{e.class}: #{e.message}")
+      {error: e.message}
+    end
+
+    def build_context
+      day_range = TrainingWeek.day_range(@date)
+      yesterday_range = TrainingWeek.day_range(@date - 1)
+      plan = @user.plan
+
+      metrics = %w[resting_heart_rate heart_rate_variability sleep_analysis weight active_energy basal_energy_burned].each_with_object({}) do |name, h|
+        val = @user.health_metrics.where(metric_name: name, recorded_at: day_range)
+          .order(recorded_at: :desc).first&.value&.to_f
+        h[name] = val if val
+      end
+
+      yesterday_metrics = %w[resting_heart_rate heart_rate_variability sleep_analysis weight].each_with_object({}) do |name, h|
+        val = @user.health_metrics.where(metric_name: name, recorded_at: yesterday_range)
+          .order(recorded_at: :desc).first&.value&.to_f
+        h[name] = val if val
+      end
+
+      food = @user.food_logs.where(consumed_at: day_range)
+      nutrition_profile = @user.nutrition_profile
+      workouts = @user.workouts.where(started_at: day_range).order(:started_at)
+
+      <<~CONTEXT
+        ## Date
+        #{@date.strftime("%A, %B %-d, %Y")}
+
+        ## Today's Metrics
+        #{format_metrics(metrics)}
+
+        ## Yesterday's Metrics (for comparison)
+        #{format_metrics(yesterday_metrics)}
+
+        ## Nutrition
+        #{format_nutrition(food, nutrition_profile)}
+
+        ## Today's Workouts
+        #{format_workouts(workouts)}
+
+        ## Training Plan
+        #{plan&.content || "No plan on file."}
+      CONTEXT
+    end
+
+    def format_metrics(metrics)
+      return "No data." if metrics.empty?
+      lines = []
+      lines << "RHR: #{metrics["resting_heart_rate"].round} bpm" if metrics["resting_heart_rate"]
+      lines << "HRV: #{metrics["heart_rate_variability"].round} ms" if metrics["heart_rate_variability"]
+      lines << "Sleep: #{metrics["sleep_analysis"].round(1)} h" if metrics["sleep_analysis"]
+      lines << "Weight: #{metrics["weight"]} kg" if metrics["weight"]
+      lines << "Active energy: #{metrics["active_energy"].round} kcal" if metrics["active_energy"]
+      lines << "Basal energy: #{metrics["basal_energy_burned"].round} kcal" if metrics["basal_energy_burned"]
+      lines.join(", ")
+    end
+
+    def format_nutrition(food, nutrition_profile)
+      return "No food logged." unless food.exists?
+      parts = ["Calories: #{food.sum(:kcal).round} kcal"]
+      parts << "target: #{nutrition_profile.calorie_target.round} kcal" if nutrition_profile&.calorie_target
+      parts << "Protein: #{food.sum(:protein).round}g"
+      parts << "Fat: #{food.sum(:fat).round}g"
+      parts << "Carbs: #{food.sum(:carbs).round}g"
+      alcohol = food.sum(:alcohol).to_f
+      parts << "Alcohol: #{(alcohol / 14.0).round(1)} drinks" if alcohol.positive?
+      parts.join(", ")
+    end
+
+    def format_workouts(workouts)
+      return "No workouts." if workouts.empty?
+      workouts.map do |w|
+        parts = ["#{w.workout_type} #{(w.duration / 60.0).round} min"]
+        parts << "#{w.distance} #{w.distance_units}" if w.distance.present?
+        avg_hr = w.metadata&.dig("heartRate", "avg")
+        parts << "avg HR #{avg_hr.round}" if avg_hr
+        parts << "#{w.energy_burned.round} kcal" if w.energy_burned.present?
+        parts.join(", ")
+      end.join("\n")
+    end
+  end
+end

--- a/app/services/notion/daily_log_sync.rb
+++ b/app/services/notion/daily_log_sync.rb
@@ -63,7 +63,7 @@ module Notion
         "Sleep Hours" => latest_metric("sleep_analysis"),
         "HRV" => latest_metric("heart_rate_variability"),
         "RHR" => latest_metric("resting_heart_rate")
-      }.each { |key, value| props[key] = Properties.number(value) if value }
+      }.each { |key, value| props[key] = Properties.number(value.round(2)) if value }
 
       burned = sum_metric("active_energy") + sum_metric("basal_energy_burned")
       props["Calories Burned"] = Properties.number(burned.round) if burned.positive?

--- a/app/services/notion/daily_log_sync.rb
+++ b/app/services/notion/daily_log_sync.rb
@@ -1,0 +1,102 @@
+module Notion
+  class DailyLogSync
+    Result = Struct.new(:success, :page_id, :created, :error, keyword_init: true)
+
+    GRAMS_PER_DRINK = 14.0
+    DAY_TYPE_RANK = ["Rest", "Golf", "Strength", "Easy Run", "Hard Run", "Long Run"].freeze
+
+    def self.call(user, date:, day_type: nil, client: Client.new)
+      new(user, date: date, day_type: day_type, client: client).call
+    end
+
+    def initialize(user, date:, day_type:, client:)
+      @user = user
+      @date = date
+      @day_type = day_type || "Rest"
+      @client = client
+    end
+
+    def call
+      page = find_page
+      properties = data_properties
+      if page
+        if upgrade_day_type?(Properties.read_select(page["properties"]["Day Type"]))
+          properties["Day Type"] = Properties.select(@day_type)
+        end
+        @client.update_page(page["id"], properties: properties)
+        Result.new(success: true, page_id: page["id"], created: false)
+      else
+        properties["Day"] = Properties.title(training_week.daily_title(@day_type))
+        properties["Date"] = Properties.date(@date)
+        properties["Day Type"] = Properties.select(@day_type)
+        response = @client.create_page(data_source_id: ds_id, properties: properties)
+        Result.new(success: true, page_id: response["id"], created: true)
+      end
+    rescue => e
+      Rails.logger.error("Notion::DailyLogSync failed for #{@date}: #{e.class}: #{e.message}")
+      Result.new(success: false, error: e.message)
+    end
+
+    private
+
+    def ds_id = ENV.fetch("NOTION_DAILY_LOGS_DS_ID")
+
+    def training_week = TrainingWeek.new(@date)
+
+    def find_page
+      @client.query_data_source(ds_id,
+        filter: {"property" => "Date", "date" => {"equals" => @date.iso8601}}).first
+    end
+
+    def upgrade_day_type?(current)
+      return false if @day_type == "Rest"
+      current_rank = DAY_TYPE_RANK.index(current)
+      new_rank = DAY_TYPE_RANK.index(@day_type)
+      return false if new_rank.nil?
+      current.blank? || (current_rank && new_rank > current_rank)
+    end
+
+    def data_properties
+      props = {}
+      props["Weight (kg)"] = Properties.number(latest_metric("weight")) if latest_metric("weight")
+      props["Sleep Hours"] = Properties.number(latest_metric("sleep_analysis")) if latest_metric("sleep_analysis")
+      props["HRV"] = Properties.number(latest_metric("heart_rate_variability")) if latest_metric("heart_rate_variability")
+      props["RHR"] = Properties.number(latest_metric("resting_heart_rate")) if latest_metric("resting_heart_rate")
+
+      burned = sum_metric("active_energy") + sum_metric("basal_energy_burned")
+      props["Calories Burned"] = Properties.number(burned.round) if burned.positive?
+
+      food = @user.food_logs.where(consumed_at: day_range)
+      if food.exists?
+        actual = food.sum(:kcal).to_f
+        props["Calories Actual"] = Properties.number(actual.round)
+        props["Protein (g)"] = Properties.number(food.sum(:protein).round)
+        props["Fat (g)"] = Properties.number(food.sum(:fat).round)
+        props["Carbs (g)"] = Properties.number(food.sum(:carbs).round)
+        props["Deficit"] = Properties.number((actual - burned).round) if burned.positive?
+
+        alcohol_grams = food.sum(:alcohol).to_f
+        if alcohol_grams.positive?
+          props["Alcohol (drinks)"] = Properties.number(((alcohol_grams / GRAMS_PER_DRINK) * 2).round / 2.0)
+        end
+      end
+
+      target = @user.nutrition_profile&.calorie_target
+      props["Calories Target"] = Properties.number(target) if target
+      props
+    end
+
+    def day_range = TrainingWeek.day_range(@date)
+
+    def latest_metric(name)
+      @latest ||= {}
+      @latest[name] ||= @user.health_metrics
+        .where(metric_name: name, recorded_at: day_range)
+        .order(recorded_at: :desc).first&.value&.to_f
+    end
+
+    def sum_metric(name)
+      @user.health_metrics.where(metric_name: name, recorded_at: day_range).sum(:value).to_f
+    end
+  end
+end

--- a/app/services/notion/daily_log_sync.rb
+++ b/app/services/notion/daily_log_sync.rb
@@ -58,10 +58,12 @@ module Notion
 
     def data_properties
       props = {}
-      props["Weight (kg)"] = Properties.number(latest_metric("weight")) if latest_metric("weight")
-      props["Sleep Hours"] = Properties.number(latest_metric("sleep_analysis")) if latest_metric("sleep_analysis")
-      props["HRV"] = Properties.number(latest_metric("heart_rate_variability")) if latest_metric("heart_rate_variability")
-      props["RHR"] = Properties.number(latest_metric("resting_heart_rate")) if latest_metric("resting_heart_rate")
+      {
+        "Weight (kg)" => latest_metric("weight"),
+        "Sleep Hours" => latest_metric("sleep_analysis"),
+        "HRV" => latest_metric("heart_rate_variability"),
+        "RHR" => latest_metric("resting_heart_rate")
+      }.each { |key, value| props[key] = Properties.number(value) if value }
 
       burned = sum_metric("active_energy") + sum_metric("basal_energy_burned")
       props["Calories Burned"] = Properties.number(burned.round) if burned.positive?
@@ -90,7 +92,8 @@ module Notion
 
     def latest_metric(name)
       @latest ||= {}
-      @latest[name] ||= @user.health_metrics
+      return @latest[name] if @latest.key?(name)
+      @latest[name] = @user.health_metrics
         .where(metric_name: name, recorded_at: day_range)
         .order(recorded_at: :desc).first&.value&.to_f
     end

--- a/app/services/notion/properties.rb
+++ b/app/services/notion/properties.rb
@@ -1,0 +1,39 @@
+module Notion
+  module Properties
+    TEXT_LIMIT = 2000
+
+    module_function
+
+    def title(text) = {"title" => [{"text" => {"content" => text.to_s[0, TEXT_LIMIT]}}]}
+
+    def rich_text(text) = {"rich_text" => [{"text" => {"content" => text.to_s[0, TEXT_LIMIT]}}]}
+
+    def number(value) = {"number" => value&.to_f}
+
+    def date(d) = {"date" => {"start" => d.iso8601}}
+
+    def select(name) = {"select" => {"name" => name}}
+
+    def multi_select(names) = {"multi_select" => names.map { |n| {"name" => n} }}
+
+    def checkbox(value) = {"checkbox" => !!value}
+
+    def paragraph_block(text)
+      {
+        "object" => "block",
+        "type" => "paragraph",
+        "paragraph" => {"rich_text" => [{"text" => {"content" => text.to_s[0, TEXT_LIMIT]}}]}
+      }
+    end
+
+    def read_select(prop) = prop&.dig("select", "name")
+
+    def read_multi_select(prop) = Array(prop&.dig("multi_select")).map { |o| o["name"] }
+
+    def read_number(prop) = prop&.dig("number")
+
+    def read_title(prop) = Array(prop&.dig("title")).map { |t| t["plain_text"] }.join
+
+    def read_date(prop) = prop&.dig("date", "start")
+  end
+end

--- a/app/services/notion/red_flag_detector.rb
+++ b/app/services/notion/red_flag_detector.rb
@@ -1,0 +1,61 @@
+module Notion
+  class RedFlagDetector
+    RHR_DELTA_BPM = 5          # today's RHR this much above 7-day baseline
+    HRV_DROP_RATIO = 0.8       # today's HRV below 80% of 7-day baseline
+    SLEEP_MIN_HOURS = 6.5
+    WEEKLY_WEIGHT_LOSS_KG = 1.0 # more than 1 kg lost vs 7 days ago
+
+    def self.call(user, date:)
+      new(user, date: date).call
+    end
+
+    def initialize(user, date:)
+      @user = user
+      @date = date
+    end
+
+    def call
+      flags = []
+      flags << "RHR up" if rhr_up?
+      flags << "HRV down" if hrv_down?
+      flags << "Sleep <6.5h" if sleep_short?
+      flags << "Weight loss too fast" if weight_loss_too_fast?
+      flags
+    end
+
+    private
+
+    def day_value(name, date = @date)
+      @user.health_metrics.where(metric_name: name, recorded_at: TrainingWeek.day_range(date))
+        .order(recorded_at: :desc).first&.value&.to_f
+    end
+
+    def baseline(name)
+      range = TrainingWeek.day_range(@date - 7).first..TrainingWeek.day_range(@date - 1).last
+      values = @user.health_metrics.where(metric_name: name, recorded_at: range).pluck(:value)
+      return nil if values.empty?
+      values.sum.to_f / values.size
+    end
+
+    def rhr_up?
+      today, base = day_value("resting_heart_rate"), baseline("resting_heart_rate")
+      today && base && today >= base + RHR_DELTA_BPM
+    end
+
+    def hrv_down?
+      today, base = day_value("heart_rate_variability"), baseline("heart_rate_variability")
+      today && base && today <= base * HRV_DROP_RATIO
+    end
+
+    def sleep_short?
+      sleep = day_value("sleep_analysis")
+      sleep && sleep < SLEEP_MIN_HOURS
+    end
+
+    def weight_loss_too_fast?
+      today = day_value("weight")
+      week_ago = (1..3).lazy.map { |i| day_value("weight", @date - 7 - i + 1) }.find(&:itself) # nearest reading ~7 days back
+      today && week_ago && (week_ago - today) > WEEKLY_WEIGHT_LOSS_KG
+    end
+  end
+end

--- a/app/services/notion/training_week.rb
+++ b/app/services/notion/training_week.rb
@@ -1,0 +1,33 @@
+module Notion
+  class TrainingWeek
+    TIME_ZONE = "America/Los_Angeles"
+
+    def self.today
+      Time.now.in_time_zone(TIME_ZONE).to_date
+    end
+
+    def self.day_range(date)
+      tz = ActiveSupport::TimeZone[TIME_ZONE]
+      tz.local(date.year, date.month, date.day).all_day
+    end
+
+    def initialize(date, week1_start: Date.parse(ENV.fetch("TRAINING_WEEK1_START")))
+      @date = date
+      @week1_start = week1_start
+    end
+
+    attr_reader :date
+
+    def week_number = ((@date - @week1_start).to_i / 7) + 1
+
+    def day_number = ((@date - @week1_start).to_i % 7) + 1
+
+    def week_start = @week1_start + ((week_number - 1) * 7)
+
+    def label = "W#{week_number} D#{day_number}"
+
+    def daily_title(day_type)
+      "#{@date.strftime("%a %b %-d")} (#{label}) - #{day_type}"
+    end
+  end
+end

--- a/app/services/notion/weekly_review_generator.rb
+++ b/app/services/notion/weekly_review_generator.rb
@@ -16,6 +16,8 @@ module Notion
 
     VALID_STATUSES = ["On Track", "Cautious", "Concern", "Off Plan"].freeze
 
+    InvalidStatusError = Class.new(StandardError)
+
     SYSTEM_PROMPT = <<~PROMPT
       You are a running coach writing a weekly training review for an athlete preparing
       for the SF Half Marathon (race day: 2026-07-26). Given the week's aggregated data,
@@ -209,16 +211,20 @@ module Notion
         #{plan&.content || "No plan on file."}
       CONTEXT
 
+      # Transport/API errors propagate to the outer rescue in #call — a failed
+      # LLM call must fail the run, not masquerade as a Cautious review.
       response = RubyLLM.chat(model: ENV.fetch("LLM_MODEL", "gpt-5-nano"))
         .with_params(reasoning_effort: "medium")
         .with_instructions(SYSTEM_PROMPT)
         .ask(context)
 
-      content = response.content
-      raw = content[/\{.*\}/m]
-      parsed = JSON.parse(raw.to_s)
+      parse_llm_response(response.content)
+    end
+
+    def parse_llm_response(content)
+      parsed = JSON.parse(content.to_s[/\{.*\}/m].to_s)
       status = parsed["status"]
-      raise "invalid status: #{status.inspect}" unless VALID_STATUSES.include?(status)
+      raise InvalidStatusError, "invalid status: #{status.inspect}" unless VALID_STATUSES.include?(status)
 
       {
         status: status,
@@ -226,10 +232,9 @@ module Notion
         what_broke: parsed["what_broke"].to_s,
         adjustment: parsed["adjustment_for_next_week"].to_s
       }
-    rescue => e
-      Rails.logger.error("Notion::WeeklyReviewGenerator LLM failed for #{@date}: #{e.class}: #{e.message}")
-      raw_text = (defined?(content) && content) ? content.to_s : e.message.to_s
-      {status: "Cautious", what_worked: raw_text, what_broke: "", adjustment: "", fallback: true}
+    rescue JSON::ParserError, InvalidStatusError => e
+      Rails.logger.error("Notion::WeeklyReviewGenerator LLM output invalid for #{@date}: #{e.message}")
+      {status: "Cautious", what_worked: content.to_s, what_broke: "", adjustment: ""}
     end
 
     def build_properties(aggregates, red_flags, llm_result)

--- a/app/services/notion/weekly_review_generator.rb
+++ b/app/services/notion/weekly_review_generator.rb
@@ -171,11 +171,14 @@ module Notion
       end.uniq
 
       mapped = raw_flags.map { |f| FLAG_MAP.fetch(f, f) }.select { |f| ALLOWED_RED_FLAGS.include?(f) }.uniq
-      mapped << "Multiple red flags" if mapped.size >= 3 && !mapped.include?("Multiple red flags")
 
-      # Merge with existing page flags (merge-only on update)
+      # Merge with existing page flags (merge-only on update), then threshold
       existing_flags = existing_page ? Properties.read_multi_select(existing_page.dig("properties", "Red Flags Triggered")) : []
-      (existing_flags | mapped).sort
+      merged = (existing_flags | mapped).sort
+      if merged.count { |f| f != "Multiple red flags" } >= 3 && !merged.include?("Multiple red flags")
+        merged = (merged << "Multiple red flags").sort
+      end
+      merged
     end
 
     def call_llm(aggregates, red_flags, week)

--- a/app/services/notion/weekly_review_generator.rb
+++ b/app/services/notion/weekly_review_generator.rb
@@ -1,0 +1,261 @@
+module Notion
+  class WeeklyReviewGenerator
+    Result = Struct.new(:success, :page_id, :created, :error, keyword_init: true)
+
+    ALLOWED_RED_FLAGS = [
+      "RHR up", "HRV down", "Weight loss too fast", "Sleep short",
+      "Cold intolerance", "Hair shedding", "Low mood", "Brain fog",
+      "Soreness >48h", "Sharp pain", "Bleed change", "Quality pace miss",
+      "Multiple red flags"
+    ].freeze
+
+    # Maps Daily Logs option names → Weekly Reviews option names
+    FLAG_MAP = {
+      "Sleep <6.5h" => "Sleep short"
+    }.freeze
+
+    VALID_STATUSES = ["On Track", "Cautious", "Concern", "Off Plan"].freeze
+
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a running coach writing a weekly training review for an athlete preparing
+      for the SF Half Marathon (race day: 2026-07-26). Given the week's aggregated data,
+      training plan context, and any red flags, produce a strict JSON object with exactly
+      these keys: "status", "what_worked", "what_broke", "adjustment_for_next_week".
+
+      "status" must be exactly one of: "On Track", "Cautious", "Concern", "Off Plan".
+      The other three values are strings of plain prose (no bullet points, no markdown).
+
+      Respond with ONLY the JSON object — no preamble, no explanation, no code fences.
+    PROMPT
+
+    def self.call(user, date:, client: Client.new)
+      new(user, date: date, client: client).call
+    end
+
+    def initialize(user, date:, client:)
+      @user = user
+      @date = date
+      @client = client
+    end
+
+    def call
+      week = TrainingWeek.new(@date)
+      week_start = week.week_start
+      week_end = week_start + 6
+
+      existing_page = find_existing_page(week_start)
+      aggregates = compute_aggregates(week, week_start, week_end)
+      red_flags = compute_red_flags(week_start, week_end, existing_page)
+      llm_result = call_llm(aggregates, red_flags, week)
+
+      properties = build_properties(aggregates, red_flags, llm_result)
+
+      if existing_page
+        @client.update_page(existing_page["id"], properties: properties)
+        Result.new(success: true, page_id: existing_page["id"], created: false)
+      else
+        properties.merge!(create_only_properties(week))
+        response = @client.create_page(
+          data_source_id: ENV.fetch("NOTION_WEEKLY_REVIEWS_DS_ID"),
+          properties: properties
+        )
+        Result.new(success: true, page_id: response["id"], created: true)
+      end
+    rescue => e
+      Rails.logger.error("Notion::WeeklyReviewGenerator failed for #{@date}: #{e.class}: #{e.message}")
+      Result.new(success: false, error: e.message)
+    end
+
+    private
+
+    def find_existing_page(week_start)
+      @client.query_data_source(
+        ENV.fetch("NOTION_WEEKLY_REVIEWS_DS_ID"),
+        filter: {"property" => "Week Start", "date" => {"equals" => week_start.iso8601}}
+      ).first
+    end
+
+    def compute_aggregates(week, week_start, week_end)
+      workout_rows = fetch_workout_rows(week_start, week_end)
+      db_aggregates = compute_db_aggregates(week_start, week_end)
+
+      done_rows = workout_rows.select { |r| Properties.read_select(r.dig("properties", "Status")) == "Done" }
+
+      planned_km = workout_rows.sum { |r| r.dig("properties", "Planned Distance (km)", "number").to_f }
+      actual_km = done_rows.sum { |r| r.dig("properties", "Actual Distance (km)", "number").to_f }
+
+      long_done = done_rows.select { |r| Properties.read_select(r.dig("properties", "Type")) == "Long" }
+      long_run_km = long_done.map { |r| r.dig("properties", "Actual Distance (km)", "number").to_f }.max
+
+      quality_done = done_rows.any? { |r| Properties.read_select(r.dig("properties", "Type")) == "Quality" }
+      strength_done = done_rows.any? { |r| Properties.read_select(r.dig("properties", "Type")) == "Strength" }
+
+      {
+        planned_km: planned_km.positive? ? planned_km.round(2) : nil,
+        actual_km: actual_km.positive? ? actual_km.round(2) : nil,
+        long_run_km: long_run_km&.positive? ? long_run_km.round(2) : nil,
+        quality_done: quality_done,
+        strength_done: strength_done,
+        avg_hrv: db_aggregates[:avg_hrv],
+        avg_rhr: db_aggregates[:avg_rhr],
+        avg_sleep: db_aggregates[:avg_sleep],
+        weight_start: db_aggregates[:weight_start],
+        weight_end: db_aggregates[:weight_end]
+      }
+    end
+
+    def fetch_workout_rows(week_start, week_end)
+      @client.query_data_source(
+        ENV.fetch("NOTION_WORKOUTS_DS_ID"),
+        filter: {
+          "and" => [
+            {"property" => "Date", "date" => {"on_or_after" => week_start.iso8601}},
+            {"property" => "Date", "date" => {"on_or_before" => week_end.iso8601}}
+          ]
+        }
+      )
+    end
+
+    def compute_db_aggregates(week_start, week_end)
+      # Collect daily latest values across the week
+      hrv_values = []
+      rhr_values = []
+      sleep_values = []
+      weight_readings = []
+
+      (week_start..week_end).each do |day|
+        day_range = TrainingWeek.day_range(day)
+
+        hrv = @user.health_metrics.where(metric_name: "heart_rate_variability", recorded_at: day_range)
+          .order(recorded_at: :desc).first&.value&.to_f
+        hrv_values << hrv if hrv
+
+        rhr = @user.health_metrics.where(metric_name: "resting_heart_rate", recorded_at: day_range)
+          .order(recorded_at: :desc).first&.value&.to_f
+        rhr_values << rhr if rhr
+
+        sleep = @user.health_metrics.where(metric_name: "sleep_analysis", recorded_at: day_range)
+          .order(recorded_at: :desc).first&.value&.to_f
+        sleep_values << sleep if sleep
+
+        weight = @user.health_metrics.where(metric_name: "weight", recorded_at: day_range)
+          .order(recorded_at: :desc).first&.value&.to_f
+        weight_readings << {day: day, value: weight} if weight
+      end
+
+      avg_hrv = hrv_values.empty? ? nil : (hrv_values.sum / hrv_values.size).round(1)
+      avg_rhr = rhr_values.empty? ? nil : (rhr_values.sum / rhr_values.size).round(1)
+      avg_sleep = sleep_values.empty? ? nil : (sleep_values.sum / sleep_values.size).round(2)
+
+      weight_start = weight_readings.min_by { |r| r[:day] }&.dig(:value)
+      weight_end = weight_readings.max_by { |r| r[:day] }&.dig(:value)
+
+      {avg_hrv: avg_hrv, avg_rhr: avg_rhr, avg_sleep: avg_sleep,
+       weight_start: weight_start, weight_end: weight_end}
+    end
+
+    def compute_red_flags(week_start, week_end, existing_page)
+      daily_log_rows = @client.query_data_source(
+        ENV.fetch("NOTION_DAILY_LOGS_DS_ID"),
+        filter: {
+          "and" => [
+            {"property" => "Date", "date" => {"on_or_after" => week_start.iso8601}},
+            {"property" => "Date", "date" => {"on_or_before" => week_end.iso8601}}
+          ]
+        }
+      )
+
+      # Collect all flags from daily logs, map names, filter to allowed
+      raw_flags = daily_log_rows.flat_map do |row|
+        Properties.read_multi_select(row.dig("properties", "Red Flags"))
+      end.uniq
+
+      mapped = raw_flags.map { |f| FLAG_MAP.fetch(f, f) }.select { |f| ALLOWED_RED_FLAGS.include?(f) }.uniq
+      mapped << "Multiple red flags" if mapped.size >= 3 && !mapped.include?("Multiple red flags")
+
+      # Merge with existing page flags (merge-only on update)
+      existing_flags = existing_page ? Properties.read_multi_select(existing_page.dig("properties", "Red Flags Triggered")) : []
+      (existing_flags | mapped).sort
+    end
+
+    def call_llm(aggregates, red_flags, week)
+      race_date = Date.new(2026, 7, 26)
+      days_to_race = (race_date - @date).to_i
+      plan = @user.plan
+
+      context = <<~CONTEXT
+        ## Week #{week.week_number} Summary (#{week.week_start.strftime("%b %-d")} - #{(week.week_start + 6).strftime("%b %-d")})
+        Race day: 2026-07-26 (#{days_to_race} days away)
+
+        ## Training Aggregates
+        Planned km: #{aggregates[:planned_km] || "N/A"}
+        Actual km: #{aggregates[:actual_km] || "N/A"}
+        Long Run Distance (km): #{aggregates[:long_run_km] || "N/A"}
+        Quality Session Done: #{aggregates[:quality_done]}
+        Strength Done: #{aggregates[:strength_done]}
+        Avg HRV: #{aggregates[:avg_hrv] || "N/A"}
+        Avg RHR: #{aggregates[:avg_rhr] || "N/A"}
+        Avg Sleep Hours: #{aggregates[:avg_sleep] || "N/A"}
+        Weight Start (kg): #{aggregates[:weight_start] || "N/A"}
+        Weight End (kg): #{aggregates[:weight_end] || "N/A"}
+
+        ## Red Flags
+        #{red_flags.empty? ? "None" : red_flags.join(", ")}
+
+        ## Training Plan
+        #{plan&.content || "No plan on file."}
+      CONTEXT
+
+      response = RubyLLM.chat(model: ENV.fetch("LLM_MODEL", "gpt-5-nano"))
+        .with_params(reasoning_effort: "medium")
+        .with_instructions(SYSTEM_PROMPT)
+        .ask(context)
+
+      content = response.content
+      raw = content[/\{.*\}/m]
+      parsed = JSON.parse(raw.to_s)
+      status = parsed["status"]
+      raise "invalid status: #{status.inspect}" unless VALID_STATUSES.include?(status)
+
+      {
+        status: status,
+        what_worked: parsed["what_worked"].to_s,
+        what_broke: parsed["what_broke"].to_s,
+        adjustment: parsed["adjustment_for_next_week"].to_s
+      }
+    rescue => e
+      Rails.logger.error("Notion::WeeklyReviewGenerator LLM failed for #{@date}: #{e.class}: #{e.message}")
+      raw_text = (defined?(content) && content) ? content.to_s : e.message.to_s
+      {status: "Cautious", what_worked: raw_text, what_broke: "", adjustment: "", fallback: true}
+    end
+
+    def build_properties(aggregates, red_flags, llm_result)
+      props = {}
+
+      props["Planned km"] = Properties.number(aggregates[:planned_km]) if aggregates[:planned_km]
+      props["Actual km"] = Properties.number(aggregates[:actual_km]) if aggregates[:actual_km]
+      props["Long Run Distance (km)"] = Properties.number(aggregates[:long_run_km]) if aggregates[:long_run_km]
+      props["Quality Session Done"] = Properties.checkbox(aggregates[:quality_done])
+      props["Strength Done"] = Properties.checkbox(aggregates[:strength_done])
+      props["Avg HRV"] = Properties.number(aggregates[:avg_hrv]) if aggregates[:avg_hrv]
+      props["Avg RHR"] = Properties.number(aggregates[:avg_rhr]) if aggregates[:avg_rhr]
+      props["Avg Sleep Hours"] = Properties.number(aggregates[:avg_sleep]) if aggregates[:avg_sleep]
+      props["Weight Start (kg)"] = Properties.number(aggregates[:weight_start]) if aggregates[:weight_start]
+      props["Weight End (kg)"] = Properties.number(aggregates[:weight_end]) if aggregates[:weight_end]
+      props["Red Flags Triggered"] = Properties.multi_select(red_flags) unless red_flags.empty?
+      props["Status"] = Properties.select(llm_result[:status])
+      props["What Worked"] = Properties.rich_text(llm_result[:what_worked]) unless llm_result[:what_worked].empty?
+      props["What Broke"] = Properties.rich_text(llm_result[:what_broke]) unless llm_result[:what_broke].empty?
+      props["Adjustment for Next Week"] = Properties.rich_text(llm_result[:adjustment]) unless llm_result[:adjustment].empty?
+      props
+    end
+
+    def create_only_properties(week)
+      {
+        "Week" => Properties.title("W#{week.week_number} (#{week.week_start.strftime("%b %-d")} - #{(week.week_start + 6).strftime("%b %-d")})"),
+        "Week Number" => Properties.number(week.week_number),
+        "Week Start" => Properties.date(week.week_start)
+      }
+    end
+  end
+end

--- a/app/services/notion/workout_commentary_generator.rb
+++ b/app/services/notion/workout_commentary_generator.rb
@@ -1,0 +1,66 @@
+module Notion
+  class WorkoutCommentaryGenerator
+    Result = Struct.new(:success, :commentary, :error, keyword_init: true)
+
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a concise running coach reviewing a single completed workout for an athlete
+      training for the SF Half Marathon. Given the workout's actual numbers, the training
+      plan, and the recent week of training, write 2-4 sentences of commentary: how the
+      session went relative to its purpose, anything notable (pace, HR, fatigue signals),
+      and what it means for the next few days. No headers, no bullet points.
+    PROMPT
+
+    def self.call(workout, client: Client.new)
+      new(workout, client: client).call
+    end
+
+    def initialize(workout, client:)
+      @workout = workout
+      @client = client
+    end
+
+    def call
+      return Result.new(success: false, error: "workout has no notion_page_id") if @workout.notion_page_id.blank?
+
+      response = RubyLLM.chat(model: ENV.fetch("LLM_MODEL", "gpt-5-nano"))
+        .with_params(reasoning_effort: "medium")
+        .with_instructions(SYSTEM_PROMPT)
+        .ask(build_context)
+
+      @client.append_blocks(@workout.notion_page_id,
+        children: [Properties.paragraph_block("🤖 Coach: #{response.content}")])
+      Result.new(success: true, commentary: response.content)
+    rescue => e
+      Rails.logger.error("Notion::WorkoutCommentaryGenerator failed for Workout##{@workout.id}: #{e.class}: #{e.message}")
+      Result.new(success: false, error: e.message)
+    end
+
+    private
+
+    def build_context
+      user = @workout.user
+      plan = user.plan
+      recent = user.workouts.where(started_at: 7.days.ago..).where.not(id: @workout.id).order(:started_at)
+
+      <<~CONTEXT
+        ## This Workout
+        #{format_workout(@workout)}
+
+        ## Training Plan
+        #{plan&.content || "No plan on file."}
+
+        ## Last 7 Days
+        #{recent.map { |w| format_workout(w) }.presence&.join("\n") || "No other workouts."}
+      CONTEXT
+    end
+
+    def format_workout(w)
+      parts = ["#{w.started_at.in_time_zone(TrainingWeek::TIME_ZONE).strftime("%a %b %-d")}: #{w.workout_type}"]
+      parts << "#{(w.duration / 60.0).round} min"
+      parts << "#{w.distance} #{w.distance_units}" if w.distance.present?
+      parts << "avg HR #{w.metadata.dig("heartRate", "avg").round}" if w.metadata&.dig("heartRate", "avg")
+      parts << "#{w.energy_burned.round} kcal" if w.energy_burned.present?
+      parts.join(", ")
+    end
+  end
+end

--- a/app/services/notion/workout_sync.rb
+++ b/app/services/notion/workout_sync.rb
@@ -1,0 +1,142 @@
+module Notion
+  class WorkoutSync
+    Result = Struct.new(:success, :newly_synced_workout_ids, :day_type, :error, keyword_init: true)
+
+    RUN_NOTION_TYPES = %w[Easy Quality Long Race].freeze
+    DAY_TYPE_FOR_NOTION_TYPE = {
+      "Long" => "Long Run", "Quality" => "Hard Run", "Race" => "Hard Run",
+      "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf"
+    }.freeze
+    MI_TO_KM = 1.609344
+
+    def self.call(user, date:, client: Client.new)
+      new(user, date: date, client: client).call
+    end
+
+    def initialize(user, date:, client:)
+      @user = user
+      @date = date
+      @client = client
+      @newly_synced = []
+      @day_types = []
+    end
+
+    def call
+      workouts = @user.workouts.where(started_at: TrainingWeek.day_range(@date)).order(:started_at)
+      workouts.each { |workout| sync_workout(workout) }
+      Result.new(success: true, newly_synced_workout_ids: @newly_synced, day_type: top_day_type)
+    rescue => e
+      Rails.logger.error("Notion::WorkoutSync failed for #{@date}: #{e.class}: #{e.message}")
+      Result.new(success: false, newly_synced_workout_ids: @newly_synced, day_type: top_day_type, error: e.message)
+    end
+
+    private
+
+    def ds_id = ENV.fetch("NOTION_WORKOUTS_DS_ID")
+
+    def sync_workout(workout)
+      if workout.notion_page_id.present?
+        @client.update_page(workout.notion_page_id, properties: actuals(workout))
+        record_day_type(linked_notion_type(workout) || fallback_day_type(workout))
+        return
+      end
+
+      candidate = claim_candidate(workout)
+      if candidate
+        @client.update_page(candidate["id"],
+          properties: actuals(workout).merge("Status" => Properties.select("Done")))
+        workout.update!(notion_page_id: candidate["id"])
+        record_day_type(DAY_TYPE_FOR_NOTION_TYPE[Properties.read_select(candidate["properties"]["Type"])])
+      else
+        response = @client.create_page(data_source_id: ds_id, properties: unplanned_properties(workout))
+        workout.update!(notion_page_id: response["id"])
+        record_day_type(fallback_day_type(workout))
+      end
+      @newly_synced << workout.id
+    end
+
+    def candidates
+      @candidates ||= @client.query_data_source(ds_id,
+        filter: {"property" => "Date", "date" => {"equals" => @date.iso8601}})
+        .select { |row| %w[Planned Modified].include?(Properties.read_select(row["properties"]["Status"])) }
+    end
+
+    def claim_candidate(workout)
+      types = compatible_notion_types(workout.workout_type)
+      match = candidates.find { |row| types.include?(Properties.read_select(row["properties"]["Type"])) }
+      @candidates.delete(match) if match
+      match
+    end
+
+    def compatible_notion_types(workout_type)
+      case workout_type
+      when /running/i then RUN_NOTION_TYPES
+      when /strength/i then ["Strength"]
+      when /golf/i then ["Golf"]
+      when /cycling|swimming|elliptical|rower|rowing/i then ["Cross"]
+      else []
+      end
+    end
+
+    def actuals(workout)
+      props = {}
+      km = distance_km(workout)
+      props["Actual Distance (km)"] = Properties.number(km.round(2)) if km
+      props["Actual Duration (min)"] = Properties.number((workout.duration / 60.0).round(1))
+      avg_hr = workout.metadata&.dig("heartRate", "avg")
+      props["Actual Avg HR"] = Properties.number(avg_hr.round) if avg_hr
+      props["Actual Avg Pace"] = Properties.rich_text(pace(workout, km)) if km&.positive?
+      props["kCal Burned"] = Properties.number(workout.energy_burned.round) if workout.energy_burned
+      props
+    end
+
+    def distance_km(workout)
+      return nil unless workout.distance
+      case workout.distance_units
+      when "mi" then workout.distance.to_f * MI_TO_KM
+      when "m" then workout.distance.to_f / 1000
+      else workout.distance.to_f
+      end
+    end
+
+    def pace(workout, km)
+      seconds_per_km = workout.duration / km
+      format("%d:%02d/km", seconds_per_km / 60, (seconds_per_km % 60).round)
+    end
+
+    def unplanned_properties(workout)
+      week = TrainingWeek.new(@date)
+      type = fallback_notion_type(workout)
+      props = actuals(workout)
+      props["Session"] = Properties.title("W#{week.week_number} #{@date.strftime("%a")} - #{workout.workout_type} (unplanned)")
+      props["Date"] = Properties.date(@date)
+      props["Status"] = Properties.select("Done")
+      props["Week"] = Properties.number(week.week_number)
+      props["Type"] = Properties.select(type) if type
+      props
+    end
+
+    def fallback_notion_type(workout)
+      case workout.workout_type
+      when /running/i then "Easy"
+      when /strength/i then "Strength"
+      when /golf/i then "Golf"
+      when /cycling|swimming|elliptical|rower|rowing/i then "Cross"
+      end
+    end
+
+    def fallback_day_type(workout)
+      DAY_TYPE_FOR_NOTION_TYPE[fallback_notion_type(workout)]
+    end
+
+    def linked_notion_type(_workout) = nil # linked pages aren't re-fetched; day type falls back
+
+    def record_day_type(day_type)
+      @day_types << day_type if day_type
+    end
+
+    def top_day_type
+      @day_types.max_by { |t| DailyLogSync::DAY_TYPE_RANK.index(t) || -1 }
+    end
+  end
+end

--- a/app/services/notion/workout_sync.rb
+++ b/app/services/notion/workout_sync.rb
@@ -100,8 +100,8 @@ module Notion
     end
 
     def pace(workout, km)
-      seconds_per_km = workout.duration / km
-      format("%d:%02d/km", seconds_per_km / 60, (seconds_per_km % 60).round)
+      total_seconds = (workout.duration / km).round
+      format("%d:%02d/km", total_seconds / 60, total_seconds % 60)
     end
 
     def unplanned_properties(workout)

--- a/app/services/notion/workout_sync.rb
+++ b/app/services/notion/workout_sync.rb
@@ -5,7 +5,8 @@ module Notion
     RUN_NOTION_TYPES = %w[Easy Quality Long Race].freeze
     DAY_TYPE_FOR_NOTION_TYPE = {
       "Long" => "Long Run", "Quality" => "Hard Run", "Race" => "Hard Run",
-      "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf"
+      "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf",
+      "Cross" => "Cross"
     }.freeze
     MI_TO_KM = 1.609344
 
@@ -41,39 +42,70 @@ module Notion
         return
       end
 
+      # 1. Claim a Planned/Modified row of compatible type
       candidate = claim_candidate(workout)
       if candidate
         @client.update_page(candidate["id"],
           properties: actuals(workout).merge("Status" => Properties.select("Done")))
         workout.update!(notion_page_id: candidate["id"])
         record_day_type(DAY_TYPE_FOR_NOTION_TYPE[Properties.read_select(candidate["properties"]["Type"])])
-      else
-        response = @client.create_page(data_source_id: ds_id, properties: unplanned_properties(workout))
-        workout.update!(notion_page_id: response["id"])
-        record_day_type(fallback_day_type(workout))
+        @newly_synced << workout.id
+        return
       end
+
+      # 2. Adopt an already-Done row of compatible type (no Status write, no newly_synced)
+      done_candidate = claim_done_candidate(workout)
+      if done_candidate
+        @client.update_page(done_candidate["id"], properties: actuals(workout))
+        workout.update!(notion_page_id: done_candidate["id"])
+        record_day_type(DAY_TYPE_FOR_NOTION_TYPE[Properties.read_select(done_candidate["properties"]["Type"])])
+        return
+      end
+
+      # 3. Create an unplanned row — only if the workout type is mapped
+      notion_type = fallback_notion_type(workout)
+      return unless notion_type
+
+      response = @client.create_page(data_source_id: ds_id, properties: unplanned_properties(workout))
+      workout.update!(notion_page_id: response["id"])
+      record_day_type(fallback_day_type(workout))
       @newly_synced << workout.id
     end
 
-    def candidates
-      @candidates ||= @client.query_data_source(ds_id,
+    def all_candidates
+      @all_candidates ||= @client.query_data_source(ds_id,
         filter: {"property" => "Date", "date" => {"equals" => @date.iso8601}})
+    end
+
+    def candidates
+      @candidates ||= all_candidates
         .select { |row| %w[Planned Modified].include?(Properties.read_select(row["properties"]["Status"])) }
     end
 
     def claim_candidate(workout)
       types = compatible_notion_types(workout.workout_type)
       match = candidates.find { |row| types.include?(Properties.read_select(row["properties"]["Type"])) }
-      @candidates.delete(match) if match
+      candidates.delete(match) if match
+      all_candidates.delete(match) if match
+      match
+    end
+
+    def claim_done_candidate(workout)
+      types = compatible_notion_types(workout.workout_type)
+      match = all_candidates.find do |row|
+        Properties.read_select(row["properties"]["Status"]) == "Done" &&
+          types.include?(Properties.read_select(row["properties"]["Type"]))
+      end
+      all_candidates.delete(match) if match
       match
     end
 
     def compatible_notion_types(workout_type)
       case workout_type
-      when /running/i then RUN_NOTION_TYPES
+      when /\brun\b|running/i then RUN_NOTION_TYPES
       when /strength/i then ["Strength"]
       when /golf/i then ["Golf"]
-      when /cycling|swimming|elliptical|rower|rowing/i then ["Cross"]
+      when /cycling|swim|elliptical|rowing|rower/i then ["Cross"]
       else []
       end
     end
@@ -118,10 +150,10 @@ module Notion
 
     def fallback_notion_type(workout)
       case workout.workout_type
-      when /running/i then "Easy"
+      when /\brun\b|running/i then "Easy"
       when /strength/i then "Strength"
       when /golf/i then "Golf"
-      when /cycling|swimming|elliptical|rower|rowing/i then "Cross"
+      when /cycling|swim|elliptical|rowing|rower/i then "Cross"
       end
     end
 

--- a/app/services/notion/workout_sync.rb
+++ b/app/services/notion/workout_sync.rb
@@ -3,10 +3,11 @@ module Notion
     Result = Struct.new(:success, :newly_synced_workout_ids, :day_type, :error, keyword_init: true)
 
     RUN_NOTION_TYPES = %w[Easy Quality Long Race].freeze
+    # No "Cross" entry: the Daily Logs Day Type select has no Cross option,
+    # and writing an unknown select name would silently add it to the schema.
     DAY_TYPE_FOR_NOTION_TYPE = {
       "Long" => "Long Run", "Quality" => "Hard Run", "Race" => "Hard Run",
-      "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf",
-      "Cross" => "Cross"
+      "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf"
     }.freeze
     MI_TO_KM = 1.609344
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -14,10 +14,10 @@ production:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
 
-  # Enable after one-shot verification (see rollout in plan):
-  # notion_catchup:
-  #   class: NotionSyncJob
-  #   schedule: every 30 minutes
+  # One-shot verification passed 2026-06-12; catchup enabled per rollout plan.
+  notion_catchup:
+    class: NotionSyncJob
+    schedule: every 30 minutes
 
   # daily_log_commentary:
   #   class: DailyLogCommentaryJob

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -18,3 +18,7 @@ production:
   # notion_catchup:
   #   class: NotionSyncJob
   #   schedule: every 30 minutes
+
+  # daily_log_commentary:
+  #   class: DailyLogCommentaryJob
+  #   schedule: "52 21 * * * America/Los_Angeles"   # 9:52pm PT daily

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -22,3 +22,7 @@ production:
   # daily_log_commentary:
   #   class: DailyLogCommentaryJob
   #   schedule: "52 21 * * * America/Los_Angeles"   # 9:52pm PT daily
+
+  # weekly_review:
+  #   class: WeeklyReviewJob
+  #   schedule: "22 21 * * 0 America/Los_Angeles"   # Sundays 9:22pm PT

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,8 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+
+  # Enable after one-shot verification (see rollout in plan):
+  # notion_catchup:
+  #   class: NotionSyncJob
+  #   schedule: every 30 minutes

--- a/db/migrate/20260612234048_add_notion_page_id_to_workouts.rb
+++ b/db/migrate/20260612234048_add_notion_page_id_to_workouts.rb
@@ -1,0 +1,6 @@
+class AddNotionPageIdToWorkouts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workouts, :notion_page_id, :string
+    add_index :workouts, :notion_page_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_30_032748) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_234048) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -245,11 +245,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_30_032748) do
     t.string "external_id", null: false
     t.jsonb "metadata"
     t.text "notes"
+    t.string "notion_page_id"
     t.datetime "started_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.string "workout_type", null: false
     t.index ["external_id"], name: "index_workouts_on_external_id", unique: true
+    t.index ["notion_page_id"], name: "index_workouts_on_notion_page_id"
     t.index ["user_id", "started_at"], name: "index_workouts_on_user_id_and_started_at"
     t.index ["user_id"], name: "index_workouts_on_user_id"
   end

--- a/docs/superpowers/plans/2026-06-12-notion-training-sync.md
+++ b/docs/superpowers/plans/2026-06-12-notion-training-sync.md
@@ -1,0 +1,1387 @@
+# Notion Training Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers-extended-cc:subagent-driven-development (if subagents available) or superpowers-extended-cc:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically keep three Notion databases (Daily Logs, Workouts, Weekly Reviews) up to date from Apple Health data in the Signals Postgres DB, including LLM commentary, with no manual Claude iOS step.
+
+**Architecture:** Webhook-chained `NotionSyncJob` (Solid Queue) syncs data fields to Notion via a minimal `Notion::Client` REST wrapper; a 30-min recurring catch-up self-heals; evening `ruby_llm` jobs write workout commentary, daily narrative + red flags, and the Sunday weekly review. Strict field ownership (automation vs human) makes every write idempotent and safe.
+
+**Tech Stack:** Rails 8.1, Solid Queue (in Puma), `ruby_llm`, `Net::HTTP` (no new gems), Notion REST API version `2025-09-03` (data-source endpoints), Minitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-notion-training-sync-design.md` — read it first; the field-ownership tables there are authoritative.
+
+---
+
+## Key facts the spec assumes (verified against codebase)
+
+- Health data arrives at `Api::V1::HealthDataController#create` → `HealthDataProcessor` → `health_metrics` / `workouts` tables. User is hardcoded: `User.find_by!(email: "jules@julescoleman.com")`.
+- Canonical `health_metrics.metric_name` values (see `MetricsParser`): `weight` (kg), `sleep_analysis` (value = total sleep hours), `heart_rate_variability` (ms), `resting_heart_rate` (bpm), `active_energy` (kcal), `basal_energy_burned` (kcal), `steps`.
+- `workouts` columns: `external_id`, `workout_type` (Apple names like `"Running"`, `"Traditional Strength Training"`, `"Golf"`), `started_at`/`ended_at` (UTC), `duration` (seconds), `distance` + `distance_units`, `energy_burned` (kcal), `metadata` (jsonb; `metadata["heartRate"]["avg"]` when present — see `WorkoutParser#build_metadata`).
+- LLM pattern to copy: `PlanSuggestionGenerator` (`RubyLLM.chat(model: ENV.fetch("LLM_MODEL", "gpt-5-nano")).with_params(reasoning_effort: "medium").with_instructions(...).ask(context)`), and its test's `stub_llm_chat` helper.
+- Runna plan text lives in `plans.content` (single `Plan` per user).
+- Tests: Minitest + fixtures (`users(:one)`, `plans(:with_content)`). No WebMock — stub objects/singleton methods, as existing tests do.
+- `config/recurring.yml` has a `production:` section; Solid Queue runs inside Puma (`SOLID_QUEUE_IN_PUMA=true` on Render).
+
+## Environment variables
+
+Add to local `.env` (NOTION_API_TOKEN is already there) and Render dashboard:
+
+```bash
+NOTION_API_TOKEN=ntn_...                                        # already set
+NOTION_DAILY_LOGS_DS_ID=78d04a40-94e2-49e7-9199-7647f9f185bb
+NOTION_WORKOUTS_DS_ID=ffb81591-e4b5-4204-bd12-45d939757458
+NOTION_WEEKLY_REVIEWS_DS_ID=a36524f3-9afd-4cf9-8be1-d0bf0b2c21fb
+TRAINING_WEEK1_START=2026-05-04   # Monday of W1. Derived from "Thu Jun 11 (W6 D4)" — Jules to confirm.
+```
+
+`.env` is NOT auto-loaded by Rails (no dotenv gem). For local `rails runner` smoke tests, prefix commands as shown in Task 3 Step 6.
+
+## Notion property-type cheat sheet (from live schemas)
+
+- **Daily Logs**: title `Day`; date `Date`; numbers `Weight (kg)`, `Sleep Hours`, `Sleep Score`, `HRV`, `RHR`, `Calories Actual`, `Calories Burned`, `Calories Target`, `Deficit`, `Protein (g)`, `Fat (g)`, `Carbs (g)`, `Alcohol (drinks)`; selects `Day Type`, `Mood`, `Withdrawal Bleed`; multi-select `Red Flags`; rich_text `Notes`.
+- **Workouts**: title `Session`; date `Date`; numbers `Actual Distance (km)`, `Actual Duration (min)`, `Actual Avg HR`, `kCal Burned`, `Planned Distance (km)`, `RPE`, `Week`; rich_text `Actual Avg Pace`, `Planned Description`, `Notes`; selects `Type` (Easy/Quality/Long/Race/Strength/Mobility/Golf/Cross/Rest), `Status` (Planned/Done/Skipped/Modified), `Felt`; checkboxes `Fueled Properly`, `Hit Prescribed Pace`.
+- **Weekly Reviews**: title `Week`; date `Week Start`; numbers `Week Number`, `Planned km`, `Actual km`, `Long Run Distance (km)`, `Avg HRV`, `Avg RHR`, `Avg Sleep Hours`, `Weight Start (kg)`, `Weight End (kg)`; checkboxes `Quality Session Done`, `Strength Done`; select `Status` (On Track/Cautious/Concern/Off Plan); multi-select `Red Flags Triggered` (note: option is `Sleep short`, not `Sleep <6.5h`); rich_text `What Worked`, `What Broke`, `Adjustment for Next Week`.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `db/migrate/..._add_notion_page_id_to_workouts.rb` | Link DB workouts to Notion pages |
+| `app/services/notion/properties.rb` | Build/read Notion property JSON (pure functions) |
+| `app/services/notion/client.rb` | HTTP wrapper: `query_data_source`, `create_page`, `update_page`, `append_blocks` |
+| `app/services/notion/training_week.rb` | Week/day numbering + PT date helpers |
+| `app/services/notion/daily_log_sync.rb` | Upsert one Daily Logs row's data fields |
+| `app/services/notion/workout_sync.rb` | Match-and-fill Workouts rows for one date |
+| `app/services/notion/red_flag_detector.rb` | Compute data-derived daily red flags |
+| `app/services/notion/workout_commentary_generator.rb` | LLM → workout page body |
+| `app/services/notion/daily_log_commentary_generator.rb` | LLM → Daily Logs `Notes` + merged Red Flags |
+| `app/services/notion/weekly_review_generator.rb` | Aggregates + LLM → Weekly Reviews row |
+| `app/jobs/notion_sync_job.rb` | Orchestrate sync for rolling window (yesterday + today PT) |
+| `app/jobs/workout_commentary_job.rb` | One-shot commentary per newly synced workout |
+| `app/jobs/daily_log_commentary_job.rb` | 10pm PT daily |
+| `app/jobs/weekly_review_job.rb` | Sunday 9pm PT |
+| `app/controllers/api/v1/health_data_controller.rb` | + enqueue `NotionSyncJob` on success |
+| `config/recurring.yml` | + three recurring entries (commented until rollout) |
+
+---
+
+### Task 1: Migration — `notion_page_id` on workouts
+
+**Files:**
+- Create: `db/migrate/<timestamp>_add_notion_page_id_to_workouts.rb` (via generator)
+
+- [ ] **Step 1: Generate and edit migration**
+
+Run: `bin/rails generate migration AddNotionPageIdToWorkouts`
+
+```ruby
+class AddNotionPageIdToWorkouts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workouts, :notion_page_id, :string
+    add_index :workouts, :notion_page_id
+  end
+end
+```
+
+- [ ] **Step 2: Migrate and verify**
+
+Run: `bin/rails db:migrate`
+Expected: migration runs; `db/schema.rb` gains `notion_page_id` + index on workouts.
+
+- [ ] **Step 3: Run full test suite to confirm nothing broke**
+
+Run: `bin/rails test`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add db/migrate db/schema.rb
+git commit -m "feat: add notion_page_id to workouts"
+```
+
+---
+
+### Task 2: `Notion::Properties`
+
+**Files:**
+- Create: `app/services/notion/properties.rb`
+- Test: `test/services/notion/properties_test.rb`
+
+- [ ] **Step 1: Write failing tests**
+
+```ruby
+require "test_helper"
+
+class Notion::PropertiesTest < ActiveSupport::TestCase
+  test "builds title, rich_text, number, date, select, multi_select, checkbox" do
+    assert_equal({"title" => [{"text" => {"content" => "Hi"}}]}, Notion::Properties.title("Hi"))
+    assert_equal({"rich_text" => [{"text" => {"content" => "note"}}]}, Notion::Properties.rich_text("note"))
+    assert_equal({"number" => 7.5}, Notion::Properties.number(7.5))
+    assert_equal({"date" => {"start" => "2026-06-12"}}, Notion::Properties.date(Date.new(2026, 6, 12)))
+    assert_equal({"select" => {"name" => "Easy Run"}}, Notion::Properties.select("Easy Run"))
+    assert_equal({"multi_select" => [{"name" => "RHR up"}, {"name" => "HRV down"}]},
+      Notion::Properties.multi_select(["RHR up", "HRV down"]))
+    assert_equal({"checkbox" => true}, Notion::Properties.checkbox(true))
+  end
+
+  test "rich_text truncates to 2000 chars" do
+    prop = Notion::Properties.rich_text("x" * 3000)
+    assert_equal 2000, prop["rich_text"].first["text"]["content"].length
+  end
+
+  test "reads values from page property JSON" do
+    assert_equal "Planned", Notion::Properties.read_select({"select" => {"name" => "Planned"}})
+    assert_nil Notion::Properties.read_select({"select" => nil})
+    assert_equal ["RHR up"], Notion::Properties.read_multi_select({"multi_select" => [{"name" => "RHR up"}]})
+    assert_equal [], Notion::Properties.read_multi_select(nil)
+    assert_equal 5.0, Notion::Properties.read_number({"number" => 5.0})
+    assert_equal "W1 Fri - 5km Easy Run",
+      Notion::Properties.read_title({"title" => [{"plain_text" => "W1 Fri - 5km Easy Run"}]})
+    assert_equal "2026-06-12", Notion::Properties.read_date({"date" => {"start" => "2026-06-12"}})
+  end
+
+  test "paragraph_block builds a body block and truncates" do
+    block = Notion::Properties.paragraph_block("hello")
+    assert_equal "paragraph", block["type"]
+    assert_equal "hello", block.dig("paragraph", "rich_text", 0, "text", "content")
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure** — `bin/rails test test/services/notion/properties_test.rb` → fails (uninitialized constant).
+
+- [ ] **Step 3: Implement**
+
+```ruby
+module Notion
+  module Properties
+    TEXT_LIMIT = 2000
+
+    module_function
+
+    def title(text) = {"title" => [{"text" => {"content" => text.to_s[0, TEXT_LIMIT]}}]}
+
+    def rich_text(text) = {"rich_text" => [{"text" => {"content" => text.to_s[0, TEXT_LIMIT]}}]}
+
+    def number(value) = {"number" => value&.to_f}
+
+    def date(d) = {"date" => {"start" => d.iso8601}}
+
+    def select(name) = {"select" => {"name" => name}}
+
+    def multi_select(names) = {"multi_select" => names.map { |n| {"name" => n} }}
+
+    def checkbox(value) = {"checkbox" => !!value}
+
+    def paragraph_block(text)
+      {
+        "object" => "block",
+        "type" => "paragraph",
+        "paragraph" => {"rich_text" => [{"text" => {"content" => text.to_s[0, TEXT_LIMIT]}}]}
+      }
+    end
+
+    def read_select(prop) = prop&.dig("select", "name")
+
+    def read_multi_select(prop) = Array(prop&.dig("multi_select")).map { |o| o["name"] }
+
+    def read_number(prop) = prop&.dig("number")
+
+    def read_title(prop) = Array(prop&.dig("title")).map { |t| t["plain_text"] }.join
+
+    def read_date(prop) = prop&.dig("date", "start")
+  end
+end
+```
+
+- [ ] **Step 4: Run tests** — same command → PASS.
+
+- [ ] **Step 5: Commit** — `git add app/services/notion test/services/notion` then `git commit -m "feat: add Notion property builders/readers"`
+
+---
+
+### Task 3: `Notion::Client`
+
+**Files:**
+- Create: `app/services/notion/client.rb`
+- Test: `test/services/notion/client_test.rb`
+
+Design: public methods build paths/bodies and delegate to a private `request(method, path, body)`; tests stub `request` (codebase convention — no WebMock).
+
+- [ ] **Step 1: Write failing tests**
+
+```ruby
+require "test_helper"
+
+class Notion::ClientTest < ActiveSupport::TestCase
+  setup do
+    @client = Notion::Client.new(token: "secret")
+    @calls = []
+    calls = @calls
+    @responses = []
+    responses = @responses
+    @client.define_singleton_method(:request) do |method, path, body|
+      calls << [method, path, body]
+      responses.shift || {"results" => [], "has_more" => false}
+    end
+  end
+
+  test "query_data_source posts filter and paginates" do
+    @responses << {"results" => [{"id" => "p1"}], "has_more" => true, "next_cursor" => "abc"}
+    @responses << {"results" => [{"id" => "p2"}], "has_more" => false}
+
+    filter = {"property" => "Date", "date" => {"equals" => "2026-06-12"}}
+    results = @client.query_data_source("ds-1", filter: filter)
+
+    assert_equal %w[p1 p2], results.map { |r| r["id"] }
+    assert_equal [:post, "/data_sources/ds-1/query", {"filter" => filter}], @calls[0]
+    assert_equal "abc", @calls[1][2]["start_cursor"]
+  end
+
+  test "create_page targets data source parent and includes children when given" do
+    @responses << {"id" => "new-page"}
+    @client.create_page(data_source_id: "ds-1", properties: {"Day" => {}}, children: [{"type" => "paragraph"}])
+
+    method, path, body = @calls[0]
+    assert_equal :post, method
+    assert_equal "/pages", path
+    assert_equal({"type" => "data_source_id", "data_source_id" => "ds-1"}, body["parent"])
+    assert body.key?("children")
+  end
+
+  test "update_page patches properties" do
+    @responses << {"id" => "p1"}
+    @client.update_page("p1", properties: {"RHR" => {"number" => 52}})
+    assert_equal [:patch, "/pages/p1", {"properties" => {"RHR" => {"number" => 52}}}], @calls[0]
+  end
+
+  test "append_blocks patches block children" do
+    @responses << {"results" => []}
+    @client.append_blocks("p1", children: [{"type" => "paragraph"}])
+    assert_equal :patch, @calls[0][0]
+    assert_equal "/blocks/p1/children", @calls[0][1]
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure** — `bin/rails test test/services/notion/client_test.rb` → fails.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+require "net/http"
+
+module Notion
+  class Client
+    Error = Class.new(StandardError)
+
+    BASE_URL = "https://api.notion.com/v1"
+    API_VERSION = "2025-09-03"
+
+    def initialize(token: ENV.fetch("NOTION_API_TOKEN"))
+      @token = token
+    end
+
+    def query_data_source(data_source_id, filter: nil)
+      results = []
+      cursor = nil
+      loop do
+        body = {}
+        body["filter"] = filter if filter
+        body["start_cursor"] = cursor if cursor
+        response = request(:post, "/data_sources/#{data_source_id}/query", body)
+        results.concat(response["results"])
+        break unless response["has_more"]
+        cursor = response["next_cursor"]
+      end
+      results
+    end
+
+    def create_page(data_source_id:, properties:, children: nil)
+      body = {
+        "parent" => {"type" => "data_source_id", "data_source_id" => data_source_id},
+        "properties" => properties
+      }
+      body["children"] = children if children
+      request(:post, "/pages", body)
+    end
+
+    def update_page(page_id, properties:)
+      request(:patch, "/pages/#{page_id}", {"properties" => properties})
+    end
+
+    def append_blocks(page_id, children:)
+      request(:patch, "/blocks/#{page_id}/children", {"children" => children})
+    end
+
+    private
+
+    def request(method, path, body)
+      uri = URI("#{BASE_URL}#{path}")
+      request_class = (method == :post) ? Net::HTTP::Post : Net::HTTP::Patch
+      req = request_class.new(uri)
+      req["Authorization"] = "Bearer #{@token}"
+      req["Notion-Version"] = API_VERSION
+      req["Content-Type"] = "application/json"
+      req.body = JSON.generate(body)
+
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+      parsed = JSON.parse(response.body)
+      unless response.is_a?(Net::HTTPSuccess)
+        raise Error, "Notion API #{response.code} on #{method.to_s.upcase} #{path}: #{parsed["message"]}"
+      end
+      parsed
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run tests** → PASS.
+
+- [ ] **Step 5: Live smoke test against the real API.** This validates the `2025-09-03` data-source endpoints and the integration's database access **before** building on them.
+
+Run:
+```bash
+bash -c 'set -a; . .env; set +a; bin/rails runner "puts Notion::Client.new.query_data_source(ENV.fetch(\"NOTION_DAILY_LOGS_DS_ID\"), filter: {\"property\" => \"Date\", \"date\" => {\"equals\" => \"2026-06-11\"}}).map { |p| Notion::Properties.read_title(p[\"properties\"][\"Day\"]) }"'
+```
+Expected: prints `Thu Jun 11 (W6 D4) - Rest` (the known existing page). **If this 404s or 400s, STOP and fix the client/API version before proceeding** — likely causes: databases not shared with the integration, or data-source endpoints differ; fall back to `Notion-Version: 2022-06-28` with `/databases/{database_id}/query` and `parent: {"database_id": ...}` (database IDs: daily `8dfee80e53554d8188bd9aa9547aae9a`, workouts `4dc78a52d00b4d47aecd219edaa4d838`, weekly `07264ddf988e447197cc8b29935820bb`).
+
+- [ ] **Step 6: Commit** — `git commit -m "feat: add minimal Notion REST client"`
+
+---
+
+### Task 4: `Notion::TrainingWeek`
+
+**Files:**
+- Create: `app/services/notion/training_week.rb`
+- Test: `test/services/notion/training_week_test.rb`
+
+- [ ] **Step 1: Write failing tests**
+
+```ruby
+require "test_helper"
+
+class Notion::TrainingWeekTest < ActiveSupport::TestCase
+  W1 = Date.new(2026, 5, 4) # Monday
+
+  test "computes week and day numbers" do
+    tw = Notion::TrainingWeek.new(Date.new(2026, 6, 11), week1_start: W1) # known: W6 D4
+    assert_equal 6, tw.week_number
+    assert_equal 4, tw.day_number
+    assert_equal Date.new(2026, 6, 8), tw.week_start
+    assert_equal "W6 D4", tw.label
+  end
+
+  test "first day of plan is W1 D1" do
+    tw = Notion::TrainingWeek.new(W1, week1_start: W1)
+    assert_equal "W1 D1", tw.label
+  end
+
+  test "daily log title format" do
+    tw = Notion::TrainingWeek.new(Date.new(2026, 6, 11), week1_start: W1)
+    assert_equal "Thu Jun 11 (W6 D4) - Rest", tw.daily_title("Rest")
+  end
+
+  test "today returns a date in Pacific time" do
+    assert_instance_of Date, Notion::TrainingWeek.today
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+```ruby
+module Notion
+  class TrainingWeek
+    TIME_ZONE = "America/Los_Angeles"
+
+    def self.today
+      Time.now.in_time_zone(TIME_ZONE).to_date
+    end
+
+    def self.day_range(date)
+      tz = ActiveSupport::TimeZone[TIME_ZONE]
+      tz.local(date.year, date.month, date.day).all_day
+    end
+
+    def initialize(date, week1_start: Date.parse(ENV.fetch("TRAINING_WEEK1_START")))
+      @date = date
+      @week1_start = week1_start
+    end
+
+    attr_reader :date
+
+    def week_number = ((@date - @week1_start).to_i / 7) + 1
+
+    def day_number = ((@date - @week1_start).to_i % 7) + 1
+
+    def week_start = @week1_start + ((week_number - 1) * 7)
+
+    def label = "W#{week_number} D#{day_number}"
+
+    def daily_title(day_type)
+      "#{@date.strftime("%a %b %-d")} (#{label}) - #{day_type}"
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run tests** → PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: add training week numbering"`
+
+---
+
+### Task 5: `Notion::DailyLogSync`
+
+**Files:**
+- Create: `app/services/notion/daily_log_sync.rb`
+- Test: `test/services/notion/daily_log_sync_test.rb`
+
+Behavior (from spec):
+- Find the row by `Date` equals; **update** data fields if found, **create** (with generated title + Date + Day Type) if not.
+- Data fields: latest-of-day `weight` → `Weight (kg)`, `sleep_analysis` → `Sleep Hours`, `heart_rate_variability` → `HRV`, `resting_heart_rate` → `RHR`; sum-of-day `active_energy + basal_energy_burned` → `Calories Burned`; `food_logs` sums → `Calories Actual` / `Protein (g)` / `Fat (g)` / `Carbs (g)`; alcohol grams ÷ 14 rounded to 0.5 → `Alcohol (drinks)`; `nutrition_profiles.calorie_target` → `Calories Target`; `Deficit` = Actual − Burned (only when both present).
+- **Omit properties whose value is nil/absent** — never write null over a human-entered value.
+- `Day Type`: on create, set from `day_type:` arg (default `"Rest"`). On update, upgrade only — write it when the new type outranks the page's current value on the rank Rest < Golf < Strength < Easy Run < Hard Run < Long Run (empty counts as lowest); never write when the current value is unranked/human-set (e.g. `Travel`) or outranks the new type. Title is set on create only — never updated (humans customize titles).
+- Human-owned, never in any payload: `Mood`, `Sleep Score`, `Withdrawal Bleed`, `Notes` (Notes belongs to the commentary generator), `Red Flags` (belongs to the commentary pass).
+- All date bucketing via `TrainingWeek.day_range(date)` (PT).
+
+Test hygiene note (applies to Tasks 5–10): tests set `ENV` keys in `setup`; capture originals and restore them in `teardown` to avoid cross-test leakage.
+
+- [ ] **Step 1: Write failing tests** (use a `FakeNotionClient` — define once in `test/services/notion/fake_notion_client.rb` and reuse in later tasks)
+
+```ruby
+# test/services/notion/fake_notion_client.rb
+class FakeNotionClient
+  attr_reader :queries, :creates, :updates, :appends
+
+  def initialize(query_results: [])
+    @query_results = query_results # array of arrays, shifted per call
+    @queries = []
+    @creates = []
+    @updates = []
+    @appends = []
+  end
+
+  def query_data_source(ds_id, filter: nil)
+    @queries << {ds_id: ds_id, filter: filter}
+    @query_results.shift || []
+  end
+
+  def create_page(data_source_id:, properties:, children: nil)
+    @creates << {ds_id: data_source_id, properties: properties, children: children}
+    {"id" => "created-#{@creates.size}", "properties" => properties}
+  end
+
+  def update_page(page_id, properties:)
+    @updates << {page_id: page_id, properties: properties}
+    {"id" => page_id}
+  end
+
+  def append_blocks(page_id, children:)
+    @appends << {page_id: page_id, children: children}
+    {"results" => []}
+  end
+end
+```
+
+```ruby
+require "test_helper"
+require_relative "fake_notion_client"
+
+class Notion::DailyLogSyncTest < ActiveSupport::TestCase
+  DATE = Date.new(2026, 6, 11)
+
+  setup do
+    @user = users(:one)
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+    noon_pt = ActiveSupport::TimeZone["America/Los_Angeles"].local(2026, 6, 11, 12)
+    @user.health_metrics.create!(metric_name: "weight", value: 61.2, units: "kg", recorded_at: noon_pt)
+    @user.health_metrics.create!(metric_name: "active_energy", value: 500, units: "kcal", recorded_at: noon_pt)
+    @user.health_metrics.create!(metric_name: "basal_energy_burned", value: 1300, units: "kcal", recorded_at: noon_pt)
+    food = @user.foods.create!(description: "test food", kcal: 1)
+    @user.food_logs.create!(food: food, consumed_at: noon_pt, kcal: 1650, protein: 140, fat: 50, carbs: 160, alcohol: 21)
+  end
+
+  test "creates page with generated title, date, day type, and data fields when none exists" do
+    client = FakeNotionClient.new(query_results: [[]])
+    result = Notion::DailyLogSync.call(@user, date: DATE, day_type: "Easy Run", client: client)
+
+    assert result.success
+    assert result.created
+    props = client.creates.first[:properties]
+    assert_equal "Thu Jun 11 (W6 D4) - Easy Run", props["Day"]["title"].first["text"]["content"]
+    assert_equal "2026-06-11", props["Date"]["date"]["start"]
+    assert_equal "Easy Run", props["Day Type"]["select"]["name"]
+    assert_equal 61.2, props["Weight (kg)"]["number"]
+    assert_equal 1800.0, props["Calories Burned"]["number"]
+    assert_equal 1650.0, props["Calories Actual"]["number"]
+    assert_equal(-150.0, props["Deficit"]["number"])
+    assert_equal 1.5, props["Alcohol (drinks)"]["number"]  # 21g / 14 = 1.5
+  end
+
+  test "updates existing page without touching human-owned fields or title" do
+    existing = {"id" => "page-1", "properties" => {"Day Type" => {"select" => {"name" => "Rest"}}}}
+    client = FakeNotionClient.new(query_results: [[existing]])
+
+    result = Notion::DailyLogSync.call(@user, date: DATE, day_type: "Long Run", client: client)
+
+    assert result.success
+    refute result.created
+    update = client.updates.first
+    assert_equal "page-1", update[:page_id]
+    props = update[:properties]
+    refute props.key?("Day")
+    refute props.key?("Mood")
+    refute props.key?("Notes")
+    refute props.key?("Red Flags")
+    assert_equal "Long Run", props["Day Type"]["select"]["name"] # Rest -> Long Run upgrade
+  end
+
+  test "does not downgrade or overwrite a human-set day type" do
+    existing = {"id" => "page-1", "properties" => {"Day Type" => {"select" => {"name" => "Travel"}}}}
+    client = FakeNotionClient.new(query_results: [[existing]])
+
+    Notion::DailyLogSync.call(@user, date: DATE, day_type: "Easy Run", client: client)
+
+    refute client.updates.first[:properties].key?("Day Type")
+  end
+
+  test "omits properties with no data" do
+    client = FakeNotionClient.new(query_results: [[]])
+    @user.health_metrics.delete_all
+    @user.food_logs.delete_all
+
+    Notion::DailyLogSync.call(@user, date: DATE, client: client)
+
+    props = client.creates.first[:properties]
+    refute props.key?("Weight (kg)")
+    refute props.key?("Deficit")
+  end
+
+  test "returns failure result on client error" do
+    client = FakeNotionClient.new
+    def client.query_data_source(*) = raise(Notion::Client::Error, "boom")
+
+    result = Notion::DailyLogSync.call(@user, date: DATE, client: client)
+
+    refute result.success
+    assert_match "boom", result.error
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+```ruby
+module Notion
+  class DailyLogSync
+    Result = Struct.new(:success, :page_id, :created, :error, keyword_init: true)
+
+    GRAMS_PER_DRINK = 14.0
+    DAY_TYPE_RANK = ["Rest", "Golf", "Strength", "Easy Run", "Hard Run", "Long Run"].freeze
+
+    def self.call(user, date:, day_type: nil, client: Client.new)
+      new(user, date: date, day_type: day_type, client: client).call
+    end
+
+    def initialize(user, date:, day_type:, client:)
+      @user = user
+      @date = date
+      @day_type = day_type || "Rest"
+      @client = client
+    end
+
+    def call
+      page = find_page
+      if page
+        properties = data_properties
+        if upgrade_day_type?(Properties.read_select(page["properties"]["Day Type"]))
+          properties["Day Type"] = Properties.select(@day_type)
+        end
+        @client.update_page(page["id"], properties: properties)
+        Result.new(success: true, page_id: page["id"], created: false)
+      else
+        properties = data_properties
+        properties["Day"] = Properties.title(training_week.daily_title(@day_type))
+        properties["Date"] = Properties.date(@date)
+        properties["Day Type"] = Properties.select(@day_type)
+        response = @client.create_page(data_source_id: ds_id, properties: properties)
+        Result.new(success: true, page_id: response["id"], created: true)
+      end
+    rescue => e
+      Rails.logger.error("Notion::DailyLogSync failed for #{@date}: #{e.class}: #{e.message}")
+      Result.new(success: false, error: e.message)
+    end
+
+    private
+
+    def ds_id = ENV.fetch("NOTION_DAILY_LOGS_DS_ID")
+
+    def training_week = TrainingWeek.new(@date)
+
+    def find_page
+      @client.query_data_source(ds_id,
+        filter: {"property" => "Date", "date" => {"equals" => @date.iso8601}}).first
+    end
+
+    def upgrade_day_type?(current)
+      return false if @day_type == "Rest"
+      current_rank = DAY_TYPE_RANK.index(current)
+      new_rank = DAY_TYPE_RANK.index(@day_type)
+      return false if new_rank.nil?
+      current.blank? || (current_rank && new_rank > current_rank)
+    end
+
+    def data_properties
+      props = {}
+      props["Weight (kg)"] = Properties.number(latest_metric("weight")) if latest_metric("weight")
+      props["Sleep Hours"] = Properties.number(latest_metric("sleep_analysis")) if latest_metric("sleep_analysis")
+      props["HRV"] = Properties.number(latest_metric("heart_rate_variability")) if latest_metric("heart_rate_variability")
+      props["RHR"] = Properties.number(latest_metric("resting_heart_rate")) if latest_metric("resting_heart_rate")
+
+      burned = sum_metric("active_energy") + sum_metric("basal_energy_burned")
+      props["Calories Burned"] = Properties.number(burned.round) if burned.positive?
+
+      food = @user.food_logs.where(consumed_at: day_range)
+      if food.exists?
+        actual = food.sum(:kcal).to_f
+        props["Calories Actual"] = Properties.number(actual.round)
+        props["Protein (g)"] = Properties.number(food.sum(:protein).round)
+        props["Fat (g)"] = Properties.number(food.sum(:fat).round)
+        props["Carbs (g)"] = Properties.number(food.sum(:carbs).round)
+        props["Deficit"] = Properties.number((actual - burned).round) if burned.positive?
+
+        alcohol_grams = food.sum(:alcohol).to_f
+        if alcohol_grams.positive?
+          props["Alcohol (drinks)"] = Properties.number(((alcohol_grams / GRAMS_PER_DRINK) * 2).round / 2.0)
+        end
+      end
+
+      target = @user.nutrition_profile&.calorie_target
+      props["Calories Target"] = Properties.number(target) if target
+      props
+    end
+
+    def day_range = TrainingWeek.day_range(@date)
+
+    def latest_metric(name)
+      @latest ||= {}
+      @latest[name] ||= @user.health_metrics
+        .where(metric_name: name, recorded_at: day_range)
+        .order(recorded_at: :desc).first&.value&.to_f
+    end
+
+    def sum_metric(name)
+      @user.health_metrics.where(metric_name: name, recorded_at: day_range).sum(:value).to_f
+    end
+  end
+end
+```
+
+Note: confirm `User` has `has_one :nutrition_profile` (check `app/models/user.rb`; adjust accessor if the association is named differently).
+
+- [ ] **Step 4: Run tests** → PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: add Notion daily log sync"`
+
+---
+
+### Task 6: `Notion::WorkoutSync`
+
+**Files:**
+- Create: `app/services/notion/workout_sync.rb`
+- Test: `test/services/notion/workout_sync_test.rb`
+
+Behavior (from spec):
+- For each DB workout with `started_at` in the PT date:
+  - If `notion_page_id` present → update actuals on that page (no status change, no commentary).
+  - Else query Workouts DS for rows with `Date` equals the date; candidates are rows whose `Status` is `Planned` or `Modified` (never `Skipped`/`Done`) and whose `Type` is compatible with the Apple `workout_type`. Match first candidate; fill actuals + `Status: Done`; persist `notion_page_id`; record as newly synced.
+  - Else create a new row: `Session` = `"W{n} {Dow} - {workout_type} (unplanned)"`, `Date`, `Type` mapped, `Status: Done`, `Week`, actuals; persist `notion_page_id`; record as newly synced.
+- Returns `Result(success:, newly_synced_workout_ids:, day_type:, error:)`. `day_type` = highest-ranked Day Type across the date's workouts (from the matched Notion `Type` when available, else from `workout_type`), nil if no workouts.
+- Actuals mapping: distance→km via `distance_units` (`km` as-is, `mi` ×1.609344, `m` ÷1000), duration→minutes (1 dp), avg HR from `metadata["heartRate"]["avg"]` (rounded), pace `mm:ss/km` from duration÷km, `kCal Burned` from `energy_burned` (rounded). Omit nil actuals.
+- Human-owned, never in payloads: `Felt`, `RPE`, `Fueled Properly`, `Hit Prescribed Pace`, `Notes`, `Planned Description`, `Planned Distance (km)`.
+
+Type compatibility and day-type maps:
+
+```ruby
+RUN_NOTION_TYPES = %w[Easy Quality Long Race].freeze
+
+def compatible_notion_types(workout_type)
+  case workout_type
+  when /running/i then RUN_NOTION_TYPES
+  when /strength/i then ["Strength"]
+  when /golf/i then ["Golf"]
+  when /cycling|swimming|elliptical|rower|rowing/i then ["Cross"]
+  else []
+  end
+end
+
+DAY_TYPE_FOR_NOTION_TYPE = {
+  "Long" => "Long Run", "Quality" => "Hard Run", "Race" => "Hard Run",
+  "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf"
+}.freeze
+```
+
+- [ ] **Step 1: Write failing tests**
+
+```ruby
+require "test_helper"
+require_relative "fake_notion_client"
+
+class Notion::WorkoutSyncTest < ActiveSupport::TestCase
+  DATE = Date.new(2026, 6, 11)
+
+  setup do
+    @user = users(:one)
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_WORKOUTS_DS_ID"] = "ds-workouts"
+    @started = ActiveSupport::TimeZone["America/Los_Angeles"].local(2026, 6, 11, 7)
+  end
+
+  def create_run(attrs = {})
+    @user.workouts.create!({
+      external_id: SecureRandom.uuid, workout_type: "Running",
+      started_at: @started, ended_at: @started + 35.minutes, duration: 2100,
+      distance: 5.0, distance_units: "km", energy_burned: 410.4,
+      metadata: {"heartRate" => {"avg" => 152.3, "min" => 110, "max" => 171}}
+    }.merge(attrs))
+  end
+
+  def planned_row(id: "plan-1", type: "Easy", status: "Planned")
+    {"id" => id, "properties" => {
+      "Type" => {"select" => {"name" => type}},
+      "Status" => {"select" => {"name" => status}}
+    }}
+  end
+
+  test "matches a planned run, fills actuals, sets Done, stores page id" do
+    workout = create_run
+    client = FakeNotionClient.new(query_results: [[planned_row]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    assert_equal [workout.id], result.newly_synced_workout_ids
+    assert_equal "Easy Run", result.day_type
+    assert_equal "plan-1", workout.reload.notion_page_id
+
+    props = client.updates.first[:properties]
+    assert_equal 5.0, props["Actual Distance (km)"]["number"]
+    assert_equal 35.0, props["Actual Duration (min)"]["number"]
+    assert_equal 152.0, props["Actual Avg HR"]["number"]
+    assert_equal "7:00/km", props["Actual Avg Pace"]["rich_text"].first["text"]["content"]
+    assert_equal 410.0, props["kCal Burned"]["number"]
+    assert_equal "Done", props["Status"]["select"]["name"]
+    refute props.key?("Felt")
+    refute props.key?("Notes")
+  end
+
+  test "ignores Skipped and Done rows as candidates and creates unplanned row" do
+    workout = create_run(workout_type: "Golf", distance: nil, distance_units: nil, metadata: {})
+    client = FakeNotionClient.new(query_results: [[planned_row(status: "Skipped", type: "Golf")]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_empty client.updates
+    create = client.creates.first
+    props = create[:properties]
+    assert_equal "W6 Thu - Golf (unplanned)", props["Session"]["title"].first["text"]["content"]
+    assert_equal "Golf", props["Type"]["select"]["name"]
+    assert_equal "Done", props["Status"]["select"]["name"]
+    assert_equal 6.0, props["Week"]["number"]
+    assert_equal "created-1", workout.reload.notion_page_id
+    assert_equal "Golf", result.day_type
+  end
+
+  test "already-linked workout updates its page without re-matching or re-announcing" do
+    workout = create_run(notion_page_id: "page-9")
+    client = FakeNotionClient.new
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_empty client.queries          # no matching query needed
+    assert_equal "page-9", client.updates.first[:page_id]
+    refute client.updates.first[:properties].key?("Status")
+    assert_empty result.newly_synced_workout_ids
+  end
+
+  test "converts miles to km" do
+    create_run(distance: 3.1, distance_units: "mi")
+    client = FakeNotionClient.new(query_results: [[planned_row]])
+
+    Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_in_delta 4.99, client.updates.first[:properties]["Actual Distance (km)"]["number"], 0.01
+  end
+
+  test "long run outranks easy for day_type" do
+    create_run
+    create_run(started_at: @started + 8.hours, ended_at: @started + 9.hours)
+    client = FakeNotionClient.new(query_results: [[planned_row(id: "p1", type: "Easy"), planned_row(id: "p2", type: "Long")], []])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_equal "Long Run", result.day_type
+  end
+
+  test "no workouts returns nil day_type and success" do
+    client = FakeNotionClient.new
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+    assert result.success
+    assert_nil result.day_type
+    assert_empty result.newly_synced_workout_ids
+  end
+end
+```
+
+Note on the multi-candidate test: the implementation must consume **one candidate per workout** (a second workout on the same date must not match the same row twice — track claimed page IDs within the run; the fake returns the remaining list on the second query OR the service queries once and consumes locally — implement the latter: query once per date, consume candidates as they're claimed).
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement** (complete code)
+
+```ruby
+module Notion
+  class WorkoutSync
+    Result = Struct.new(:success, :newly_synced_workout_ids, :day_type, :error, keyword_init: true)
+
+    RUN_NOTION_TYPES = %w[Easy Quality Long Race].freeze
+    DAY_TYPE_FOR_NOTION_TYPE = {
+      "Long" => "Long Run", "Quality" => "Hard Run", "Race" => "Hard Run",
+      "Easy" => "Easy Run", "Strength" => "Strength", "Golf" => "Golf"
+    }.freeze
+    MI_TO_KM = 1.609344
+
+    def self.call(user, date:, client: Client.new)
+      new(user, date: date, client: client).call
+    end
+
+    def initialize(user, date:, client:)
+      @user = user
+      @date = date
+      @client = client
+      @newly_synced = []
+      @day_types = []
+    end
+
+    def call
+      workouts = @user.workouts.where(started_at: TrainingWeek.day_range(@date)).order(:started_at)
+      workouts.each { |workout| sync_workout(workout) }
+      Result.new(success: true, newly_synced_workout_ids: @newly_synced, day_type: top_day_type)
+    rescue => e
+      Rails.logger.error("Notion::WorkoutSync failed for #{@date}: #{e.class}: #{e.message}")
+      Result.new(success: false, newly_synced_workout_ids: @newly_synced, day_type: top_day_type, error: e.message)
+    end
+
+    private
+
+    def ds_id = ENV.fetch("NOTION_WORKOUTS_DS_ID")
+
+    def sync_workout(workout)
+      if workout.notion_page_id.present?
+        @client.update_page(workout.notion_page_id, properties: actuals(workout))
+        record_day_type(linked_notion_type(workout) || fallback_day_type(workout))
+        return
+      end
+
+      candidate = claim_candidate(workout)
+      if candidate
+        @client.update_page(candidate["id"],
+          properties: actuals(workout).merge("Status" => Properties.select("Done")))
+        workout.update!(notion_page_id: candidate["id"])
+        record_day_type(DAY_TYPE_FOR_NOTION_TYPE[Properties.read_select(candidate["properties"]["Type"])])
+      else
+        response = @client.create_page(data_source_id: ds_id, properties: unplanned_properties(workout))
+        workout.update!(notion_page_id: response["id"])
+        record_day_type(fallback_day_type(workout))
+      end
+      @newly_synced << workout.id
+    end
+
+    def candidates
+      @candidates ||= @client.query_data_source(ds_id,
+        filter: {"property" => "Date", "date" => {"equals" => @date.iso8601}})
+        .select { |row| %w[Planned Modified].include?(Properties.read_select(row["properties"]["Status"])) }
+    end
+
+    def claim_candidate(workout)
+      types = compatible_notion_types(workout.workout_type)
+      match = candidates.find { |row| types.include?(Properties.read_select(row["properties"]["Type"])) }
+      @candidates.delete(match) if match
+      match
+    end
+
+    def compatible_notion_types(workout_type)
+      case workout_type
+      when /running/i then RUN_NOTION_TYPES
+      when /strength/i then ["Strength"]
+      when /golf/i then ["Golf"]
+      when /cycling|swimming|elliptical|rower|rowing/i then ["Cross"]
+      else []
+      end
+    end
+
+    def actuals(workout)
+      props = {}
+      km = distance_km(workout)
+      props["Actual Distance (km)"] = Properties.number(km.round(2)) if km
+      props["Actual Duration (min)"] = Properties.number((workout.duration / 60.0).round(1))
+      avg_hr = workout.metadata&.dig("heartRate", "avg")
+      props["Actual Avg HR"] = Properties.number(avg_hr.round) if avg_hr
+      props["Actual Avg Pace"] = Properties.rich_text(pace(workout, km)) if km&.positive?
+      props["kCal Burned"] = Properties.number(workout.energy_burned.round) if workout.energy_burned
+      props
+    end
+
+    def distance_km(workout)
+      return nil unless workout.distance
+      case workout.distance_units
+      when "mi" then workout.distance.to_f * MI_TO_KM
+      when "m" then workout.distance.to_f / 1000
+      else workout.distance.to_f
+      end
+    end
+
+    def pace(workout, km)
+      seconds_per_km = workout.duration / km
+      format("%d:%02d/km", seconds_per_km / 60, (seconds_per_km % 60).round)
+    end
+
+    def unplanned_properties(workout)
+      week = TrainingWeek.new(@date)
+      type = fallback_notion_type(workout)
+      props = actuals(workout)
+      props["Session"] = Properties.title("W#{week.week_number} #{@date.strftime("%a")} - #{workout.workout_type} (unplanned)")
+      props["Date"] = Properties.date(@date)
+      props["Status"] = Properties.select("Done")
+      props["Week"] = Properties.number(week.week_number)
+      props["Type"] = Properties.select(type) if type
+      props
+    end
+
+    def fallback_notion_type(workout)
+      case workout.workout_type
+      when /running/i then "Easy"
+      when /strength/i then "Strength"
+      when /golf/i then "Golf"
+      when /cycling|swimming|elliptical|rower|rowing/i then "Cross"
+      end
+    end
+
+    def fallback_day_type(workout)
+      DAY_TYPE_FOR_NOTION_TYPE[fallback_notion_type(workout)]
+    end
+
+    def linked_notion_type(_workout) = nil # linked pages aren't re-fetched; day type falls back
+
+    def record_day_type(day_type)
+      @day_types << day_type if day_type
+    end
+
+    def top_day_type
+      @day_types.max_by { |t| DailyLogSync::DAY_TYPE_RANK.index(t) || -1 }
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run tests** → PASS (also rerun daily log sync tests — `bin/rails test test/services/notion/`).
+- [ ] **Step 5: Commit** — `git commit -m "feat: add Notion workout match-and-fill sync"`
+
+---
+
+### Task 7: `NotionSyncJob` + webhook chaining + recurring entry
+
+**Files:**
+- Create: `app/jobs/notion_sync_job.rb`, `test/jobs/notion_sync_job_test.rb`
+- Modify: `app/controllers/api/v1/health_data_controller.rb` (enqueue on success), `test/controllers/api/v1/health_data_controller_test.rb` (assert enqueue)
+- Modify: `config/recurring.yml` (commented entry)
+
+- [ ] **Step 1: Write failing job test**
+
+```ruby
+require "test_helper"
+require_relative "../services/notion/fake_notion_client"
+
+class NotionSyncJobTest < ActiveJob::TestCase
+  setup do
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+    ENV["NOTION_WORKOUTS_DS_ID"] = "ds-workouts"
+    @user = users(:one)
+    @user.update!(email: "jules@julescoleman.com")
+  end
+
+  test "syncs workouts then daily log for yesterday and today, enqueues commentary for new syncs" do
+    calls = []
+    workout_result = Notion::WorkoutSync::Result.new(
+      success: true, newly_synced_workout_ids: [42], day_type: "Easy Run")
+    daily_result = Notion::DailyLogSync::Result.new(success: true, page_id: "p", created: false)
+
+    Notion::WorkoutSync.stub(:call, ->(user, date:, client:) { calls << [:workout, date]; workout_result }) do
+      Notion::DailyLogSync.stub(:call, ->(user, date:, day_type:, client:) { calls << [:daily, date, day_type]; daily_result }) do
+        NotionSyncJob.perform_now
+      end
+    end
+
+    today = Notion::TrainingWeek.today
+    assert_equal [:workout, today - 1], calls[0]
+    assert_equal [:daily, today - 1, "Easy Run"], calls[1]
+    assert_equal [:workout, today], calls[2]
+    assert_enqueued_with(job: WorkoutCommentaryJob, args: [42])
+  end
+end
+```
+
+(`Minitest::Mock`/`.stub` is available via `minitest` bundled with Rails. `WorkoutCommentaryJob` doesn't exist yet — create an empty shell in this task; its real body comes in Task 8.)
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement job + empty commentary job shell**
+
+```ruby
+class NotionSyncJob < ApplicationJob
+  limits_concurrency to: 1, key: "notion_sync"
+
+  def perform
+    user = User.find_by!(email: "jules@julescoleman.com")
+    client = Notion::Client.new
+    today = Notion::TrainingWeek.today
+
+    [today - 1, today].each do |date|
+      workout_result = Notion::WorkoutSync.call(user, date: date, client: client)
+      Notion::DailyLogSync.call(user, date: date, day_type: workout_result.day_type, client: client)
+      workout_result.newly_synced_workout_ids.each do |workout_id|
+        WorkoutCommentaryJob.perform_later(workout_id)
+      end
+    end
+  end
+end
+```
+
+```ruby
+class WorkoutCommentaryJob < ApplicationJob
+  def perform(workout_id)
+    # implemented in Task 8
+  end
+end
+```
+
+- [ ] **Step 4: Run job tests** → PASS.
+
+- [ ] **Step 5: Chain from webhook.** In `Api::V1::HealthDataController#create`, inside the `if result.success` branch, before `render`:
+
+```ruby
+NotionSyncJob.perform_later
+```
+
+Add to the existing controller test (`test/controllers/api/v1/health_data_controller_test.rb`): a successful POST enqueues `NotionSyncJob` (use `assert_enqueued_with(job: NotionSyncJob)`); a failed payload does not.
+
+- [ ] **Step 6: Add commented recurring entry** to `config/recurring.yml` under `production:`:
+
+```yaml
+  # Enable after one-shot verification (see rollout in plan):
+  # notion_catchup:
+  #   class: NotionSyncJob
+  #   schedule: every 30 minutes
+```
+
+- [ ] **Step 7: Run full suite** — `bin/rails test` → all green.
+- [ ] **Step 8: Commit** — `git commit -m "feat: add NotionSyncJob with webhook chaining"`
+
+---
+
+### Task 8: Workout commentary (generator + job)
+
+**Files:**
+- Create: `app/services/notion/workout_commentary_generator.rb`, `test/services/notion/workout_commentary_generator_test.rb`
+- Modify: `app/jobs/workout_commentary_job.rb`, create `test/jobs/workout_commentary_job_test.rb`
+
+Behavior: one `RubyLLM.chat` call (copy `PlanSuggestionGenerator`'s structure and its test's `stub_llm_chat` helper — extract that helper into `test/support/llm_stubbing.rb` and require it from both tests if convenient, or duplicate it; prefer extracting). Context: the workout's actuals, the plan content, last 7 days of workouts. Output: 2-4 sentence coach commentary. Write via `client.append_blocks(workout.notion_page_id, children: [Properties.paragraph_block("🤖 Coach: " + text)])`.
+
+Gate (from spec): the job is only ever enqueued by `WorkoutSync` for newly synced workouts — the generator itself does not check for prior commentary. A permanently failed job never re-fires; accepted.
+
+- [ ] **Step 1: Write failing generator test** — assert: (a) success path appends one paragraph block to the workout's `notion_page_id` containing the LLM text; (b) prompt includes workout type, distance, and plan content; (c) LLM failure → `Result(success: false)` and **no** `append_blocks` call; (d) workout without `notion_page_id` → failure, no API call.
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+```ruby
+module Notion
+  class WorkoutCommentaryGenerator
+    Result = Struct.new(:success, :commentary, :error, keyword_init: true)
+
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a concise running coach reviewing a single completed workout for an athlete
+      training for the SF Half Marathon. Given the workout's actual numbers, the training
+      plan, and the recent week of training, write 2-4 sentences of commentary: how the
+      session went relative to its purpose, anything notable (pace, HR, fatigue signals),
+      and what it means for the next few days. No headers, no bullet points.
+    PROMPT
+
+    def self.call(workout, client: Client.new)
+      new(workout, client: client).call
+    end
+
+    def initialize(workout, client:)
+      @workout = workout
+      @client = client
+    end
+
+    def call
+      return Result.new(success: false, error: "workout has no notion_page_id") if @workout.notion_page_id.blank?
+
+      response = RubyLLM.chat(model: ENV.fetch("LLM_MODEL", "gpt-5-nano"))
+        .with_params(reasoning_effort: "medium")
+        .with_instructions(SYSTEM_PROMPT)
+        .ask(build_context)
+
+      @client.append_blocks(@workout.notion_page_id,
+        children: [Properties.paragraph_block("🤖 Coach: #{response.content}")])
+      Result.new(success: true, commentary: response.content)
+    rescue => e
+      Rails.logger.error("Notion::WorkoutCommentaryGenerator failed for Workout##{@workout.id}: #{e.class}: #{e.message}")
+      Result.new(success: false, error: e.message)
+    end
+
+    private
+
+    def build_context
+      user = @workout.user
+      plan = user.plan
+      recent = user.workouts.where(started_at: 7.days.ago..).where.not(id: @workout.id).order(:started_at)
+
+      <<~CONTEXT
+        ## This Workout
+        #{format_workout(@workout)}
+
+        ## Training Plan
+        #{plan&.content || "No plan on file."}
+
+        ## Last 7 Days
+        #{recent.map { |w| format_workout(w) }.presence&.join("\n") || "No other workouts."}
+      CONTEXT
+    end
+
+    def format_workout(w)
+      parts = ["#{w.started_at.in_time_zone(TrainingWeek::TIME_ZONE).strftime("%a %b %-d")}: #{w.workout_type}"]
+      parts << "#{(w.duration / 60.0).round} min"
+      parts << "#{w.distance} #{w.distance_units}" if w.distance.present?
+      parts << "avg HR #{w.metadata.dig("heartRate", "avg").round}" if w.metadata&.dig("heartRate", "avg")
+      parts << "#{w.energy_burned.round} kcal" if w.energy_burned.present?
+      parts.join(", ")
+    end
+  end
+end
+```
+
+```ruby
+class WorkoutCommentaryJob < ApplicationJob
+  def perform(workout_id)
+    workout = Workout.find(workout_id)
+    result = Notion::WorkoutCommentaryGenerator.call(workout)
+    unless result.success
+      Rails.logger.error("WorkoutCommentaryJob failed for Workout##{workout_id}: #{result.error}")
+    end
+  end
+end
+```
+
+Note: confirm `User has_one :plan` and `Workout belongs_to :user` accessors against the models; adjust if named differently.
+
+- [ ] **Step 4: Run tests** → PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: add workout commentary generator and job"`
+
+---
+
+### Task 9: Red flags + daily log commentary (detector, generator, job, recurring entry)
+
+**Files:**
+- Create: `app/services/notion/red_flag_detector.rb`, `test/services/notion/red_flag_detector_test.rb`
+- Create: `app/services/notion/daily_log_commentary_generator.rb`, `test/services/notion/daily_log_commentary_generator_test.rb`
+- Create: `app/jobs/daily_log_commentary_job.rb`, `test/jobs/daily_log_commentary_job_test.rb`
+- Modify: `config/recurring.yml`
+
+**`Notion::RedFlagDetector`** — pure computation, `self.call(user, date:) -> Array<String>` of Daily Logs `Red Flags` option names:
+
+```ruby
+module Notion
+  class RedFlagDetector
+    RHR_DELTA_BPM = 5          # today's RHR this much above 7-day baseline
+    HRV_DROP_RATIO = 0.8       # today's HRV below 80% of 7-day baseline
+    SLEEP_MIN_HOURS = 6.5
+    WEEKLY_WEIGHT_LOSS_KG = 1.0 # more than 1 kg lost vs 7 days ago
+
+    def self.call(user, date:)
+      new(user, date: date).call
+    end
+
+    def initialize(user, date:)
+      @user = user
+      @date = date
+    end
+
+    def call
+      flags = []
+      flags << "RHR up" if rhr_up?
+      flags << "HRV down" if hrv_down?
+      flags << "Sleep <6.5h" if sleep_short?
+      flags << "Weight loss too fast" if weight_loss_too_fast?
+      flags
+    end
+
+    private
+
+    def day_value(name, date = @date)
+      @user.health_metrics.where(metric_name: name, recorded_at: TrainingWeek.day_range(date))
+        .order(recorded_at: :desc).first&.value&.to_f
+    end
+
+    def baseline(name)
+      range = TrainingWeek.day_range(@date - 7).first..TrainingWeek.day_range(@date - 1).last
+      values = @user.health_metrics.where(metric_name: name, recorded_at: range).pluck(:value)
+      return nil if values.empty?
+      values.sum.to_f / values.size
+    end
+
+    def rhr_up?
+      today, base = day_value("resting_heart_rate"), baseline("resting_heart_rate")
+      today && base && today >= base + RHR_DELTA_BPM
+    end
+
+    def hrv_down?
+      today, base = day_value("heart_rate_variability"), baseline("heart_rate_variability")
+      today && base && today <= base * HRV_DROP_RATIO
+    end
+
+    def sleep_short?
+      sleep = day_value("sleep_analysis")
+      sleep && sleep < SLEEP_MIN_HOURS
+    end
+
+    def weight_loss_too_fast?
+      today = day_value("weight")
+      week_ago = (1..3).lazy.map { |i| day_value("weight", @date - 7 - i + 1) }.find(&:itself) # nearest reading ~7 days back
+      today && week_ago && (week_ago - today) > WEEKLY_WEIGHT_LOSS_KG
+    end
+  end
+end
+```
+
+**`Notion::DailyLogCommentaryGenerator`** — `self.call(user, date:, client:)`:
+1. Find the day's page (same query as `DailyLogSync`); if missing, run `DailyLogSync` first to create it, then re-query.
+2. Build context: the day's metrics, food totals vs targets, the day's workouts, plan content, yesterday for comparison. One `RubyLLM.chat` call → one-paragraph narrative.
+3. Compute `RedFlagDetector` flags; merge with the page's existing `Red Flags` (union, never remove).
+4. `client.update_page(page_id, properties: {"Notes" => Properties.rich_text(narrative), "Red Flags" => Properties.multi_select(merged)})` — only include `Red Flags` when merged list differs from existing (avoid no-op churn).
+
+**`DailyLogCommentaryJob`** — `perform` → hardcoded user, `Notion::TrainingWeek.today`, call generator, log on failure.
+
+- [ ] **Step 1: Write failing detector tests** — cover: each flag trips at its threshold; no flags with no data; baselines ignore today's value.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement detector.** Run tests → PASS.
+- [ ] **Step 4: Write failing generator tests** — cover: (a) writes Notes with LLM text and merges red flags (existing `["Low mood"]` + computed `["RHR up"]` → both present); (b) never removes existing flags; (c) creates the daily page first when missing; (d) LLM failure → no update call, `success: false`. Use `FakeNotionClient` + the LLM stub helper.
+- [ ] **Step 5: Run to verify failure.**
+- [ ] **Step 6: Implement generator + job.** Run tests → PASS.
+- [ ] **Step 7: Add commented recurring entry:**
+
+```yaml
+  # daily_log_commentary:
+  #   class: DailyLogCommentaryJob
+  #   schedule: "52 21 * * * America/Los_Angeles"   # 9:52pm PT daily
+```
+
+- [ ] **Step 8: Full suite** — `bin/rails test` → green.
+- [ ] **Step 9: Commit** — `git commit -m "feat: add daily red flags and commentary generation"`
+
+---
+
+### Task 10: Weekly review (generator + job + recurring entry)
+
+**Files:**
+- Create: `app/services/notion/weekly_review_generator.rb`, `test/services/notion/weekly_review_generator_test.rb`
+- Create: `app/jobs/weekly_review_job.rb`, `test/jobs/weekly_review_job_test.rb`
+- Modify: `config/recurring.yml`
+
+**`Notion::WeeklyReviewGenerator`** — `self.call(user, date:, client:)` where `date` is any day in the target week:
+
+1. `week = TrainingWeek.new(date)`; week range = `week.week_start..week.week_start + 6`.
+2. **Upsert by `Week Start`**: query Weekly Reviews DS for `Week Start` equals `week.week_start`; update if found, create if not (a Solid Queue retry must not duplicate).
+3. Aggregates from the **Workouts DS** rows in the week range (one query, `Date` `on_or_after`/`on_or_before` compound filter):
+   - `Planned km` = sum of `Planned Distance (km)` over all rows
+   - `Actual km` = sum of `Actual Distance (km)` over `Done` rows
+   - `Long Run Distance (km)` = max `Actual Distance (km)` among `Done` rows with Type `Long`
+   - `Quality Session Done` = any `Done` row with Type `Quality`; `Strength Done` = any `Done` row with Type `Strength`
+4. Aggregates from DB: `Avg HRV` / `Avg RHR` / `Avg Sleep Hours` (averages of daily values over the week), `Weight Start (kg)` / `Weight End (kg)` (first/last weight readings in the week).
+5. `Red Flags Triggered` = union of the week's Daily Logs rows' `Red Flags` (query Daily Logs DS for the week range), mapped to Weekly option names (`"Sleep <6.5h"` → `"Sleep short"`; all other names match 1:1; drop any name not in the Weekly options list; add `"Multiple red flags"` when ≥3 distinct flags). Merge-only against existing.
+6. LLM (one call): instructions demand **strict JSON** `{"status": "On Track|Cautious|Concern|Off Plan", "what_worked": "...", "what_broke": "...", "adjustment_for_next_week": "..."}` given context (aggregates, plan content, red flags, race countdown). Parse with `JSON.parse`; on parse failure or invalid status, fall back to status `"Cautious"` and put the raw text in `What Worked`. The model may wrap JSON in code fences — strip them before parsing (`response.content[/\{.*\}/m]`).
+7. Title on create: `"W#{week.week_number} (#{week.week_start.strftime("%b %-d")} - #{(week.week_start + 6).strftime("%b %-d")})"`; `Week Number`, `Week Start` set on create.
+
+**`WeeklyReviewJob`** — hardcoded user, `Notion::TrainingWeek.today`, call generator, log failures.
+
+- [ ] **Step 1: Write failing generator tests** — cover: (a) creates row with computed aggregates + parsed LLM fields when none exists; (b) updates (not creates) when a row for `Week Start` exists; (c) red-flag name mapping incl. `Sleep short` and `Multiple red flags`; (d) malformed LLM JSON → `Cautious` fallback, still writes aggregates; (e) `Long Run Distance` only considers Done+Long rows. Use `FakeNotionClient` query_results sequencing (weekly query, workouts query, daily logs query).
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement generator + job.** Run tests → PASS.
+- [ ] **Step 4: Add commented recurring entry:**
+
+```yaml
+  # weekly_review:
+  #   class: WeeklyReviewJob
+  #   schedule: "22 21 * * 0 America/Los_Angeles"   # Sundays 9:22pm PT
+```
+
+- [ ] **Step 5: Full suite + linter** — `bin/rails test` and `bundle exec standardrb` → green.
+- [ ] **Step 6: Commit** — `git commit -m "feat: add weekly review generation"`
+
+---
+
+### Task 11: End-to-end verification + staged rollout
+
+**Files:**
+- Modify: `config/recurring.yml` (uncomment entries, staged)
+- Modify: `.env` / Render env vars (Task 0 of this section)
+
+- [ ] **Step 1: Set env vars.** Add the four non-secret vars (data source IDs + `TRAINING_WEEK1_START`) to local `.env` and the Render dashboard. **Ask Jules to confirm `TRAINING_WEEK1_START=2026-05-04`** (derived from "Thu Jun 11 (W6 D4)": W6 starts Mon Jun 8, so W1 starts Mon May 4).
+
+- [ ] **Step 2: Refresh local DB from production** — `bin/rails db:pull` (existing task) so the one-shot uses real data.
+
+- [ ] **Step 3: One-shot data sync against real Notion** (data fields only — no LLM):
+
+```bash
+bash -c 'set -a; . .env; set +a; bin/rails runner "NotionSyncJob.perform_now"'
+```
+Expected: today's (and yesterday's) Daily Logs rows update with weight/sleep/HRV/RHR/calories; any of today's workouts get actuals + Done. **Verify by eye in Notion.** Check: no human fields changed, no duplicate rows, titles untouched on existing pages.
+
+- [ ] **Step 4: One-shot commentary + weekly review dry-run** (requires `LLM_MODEL` + provider key envs — same as production):
+
+```bash
+bash -c 'set -a; . .env; set +a; bin/rails runner "DailyLogCommentaryJob.perform_now"'
+bash -c 'set -a; . .env; set +a; bin/rails runner "WeeklyReviewJob.perform_now"'
+```
+Verify in Notion: Notes narrative reads sensibly; red flags merged not replaced; weekly row upserted (run twice — second run must update, not duplicate).
+
+- [ ] **Step 5: Deploy with `notion_catchup` enabled** — uncomment only `notion_catchup` in `config/recurring.yml`, commit, push, deploy. Webhook chaining is already live from Task 7 (it's harmless alongside catchup thanks to `limits_concurrency`).
+
+- [ ] **Step 6: After one clean day** — uncomment `daily_log_commentary` and `weekly_review`, commit, push, deploy.
+
+- [ ] **Step 7: Monitor** — check `solid_queue_failed_executions` after the first evening run:
+
+```bash
+bash -c 'set -a; . .env; set +a; bin/rails runner "puts SolidQueue::FailedExecution.count"'
+```
+(against production: use the Render shell or `DATABASE_URL` override, matching how `db:pull` connects).
+
+- [ ] **Step 8: Final commit + update spec status** — mark rollout complete in the spec doc header.
+
+---
+
+## Out of scope (per spec)
+
+- MCP server / read API for Claude iOS chats
+- Multi-user support
+- Backfilling historical Notion pages

--- a/docs/superpowers/plans/2026-06-12-notion-training-sync.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-12-notion-training-sync.md.tasks.json
@@ -1,0 +1,17 @@
+{
+  "planPath": "docs/superpowers/plans/2026-06-12-notion-training-sync.md",
+  "tasks": [
+    {"id": 6, "subject": "Task 1: Migration — notion_page_id on workouts", "status": "pending"},
+    {"id": 7, "subject": "Task 2: Notion::Properties", "status": "pending"},
+    {"id": 8, "subject": "Task 3: Notion::Client", "status": "pending", "blockedBy": [7]},
+    {"id": 9, "subject": "Task 4: Notion::TrainingWeek", "status": "pending"},
+    {"id": 10, "subject": "Task 5: Notion::DailyLogSync", "status": "pending", "blockedBy": [8, 9]},
+    {"id": 11, "subject": "Task 6: Notion::WorkoutSync", "status": "pending", "blockedBy": [6, 8, 9, 10]},
+    {"id": 12, "subject": "Task 7: NotionSyncJob + webhook chaining + recurring entry", "status": "pending", "blockedBy": [10, 11]},
+    {"id": 13, "subject": "Task 8: Workout commentary generator + job", "status": "pending", "blockedBy": [12]},
+    {"id": 14, "subject": "Task 9: Red flags + daily commentary", "status": "pending", "blockedBy": [12]},
+    {"id": 15, "subject": "Task 10: Weekly review generator + job", "status": "pending", "blockedBy": [12]},
+    {"id": 16, "subject": "Task 11: End-to-end verification + staged rollout", "status": "pending", "blockedBy": [13, 14, 15]}
+  ],
+  "lastUpdated": "2026-06-12"
+}

--- a/docs/superpowers/plans/2026-06-12-notion-training-sync.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-12-notion-training-sync.md.tasks.json
@@ -1,17 +1,17 @@
 {
   "planPath": "docs/superpowers/plans/2026-06-12-notion-training-sync.md",
   "tasks": [
-    {"id": 6, "subject": "Task 1: Migration — notion_page_id on workouts", "status": "pending"},
-    {"id": 7, "subject": "Task 2: Notion::Properties", "status": "pending"},
-    {"id": 8, "subject": "Task 3: Notion::Client", "status": "pending", "blockedBy": [7]},
-    {"id": 9, "subject": "Task 4: Notion::TrainingWeek", "status": "pending"},
-    {"id": 10, "subject": "Task 5: Notion::DailyLogSync", "status": "pending", "blockedBy": [8, 9]},
-    {"id": 11, "subject": "Task 6: Notion::WorkoutSync", "status": "pending", "blockedBy": [6, 8, 9, 10]},
-    {"id": 12, "subject": "Task 7: NotionSyncJob + webhook chaining + recurring entry", "status": "pending", "blockedBy": [10, 11]},
-    {"id": 13, "subject": "Task 8: Workout commentary generator + job", "status": "pending", "blockedBy": [12]},
-    {"id": 14, "subject": "Task 9: Red flags + daily commentary", "status": "pending", "blockedBy": [12]},
-    {"id": 15, "subject": "Task 10: Weekly review generator + job", "status": "pending", "blockedBy": [12]},
-    {"id": 16, "subject": "Task 11: End-to-end verification + staged rollout", "status": "pending", "blockedBy": [13, 14, 15]}
+    {"id": 6, "subject": "Task 1: Migration — notion_page_id on workouts", "status": "completed"},
+    {"id": 7, "subject": "Task 2: Notion::Properties", "status": "completed"},
+    {"id": 8, "subject": "Task 3: Notion::Client", "status": "completed", "blockedBy": [7]},
+    {"id": 9, "subject": "Task 4: Notion::TrainingWeek", "status": "completed"},
+    {"id": 10, "subject": "Task 5: Notion::DailyLogSync", "status": "completed", "blockedBy": [8, 9]},
+    {"id": 11, "subject": "Task 6: Notion::WorkoutSync", "status": "completed", "blockedBy": [6, 8, 9, 10]},
+    {"id": 12, "subject": "Task 7: NotionSyncJob + webhook chaining + recurring entry", "status": "completed", "blockedBy": [10, 11]},
+    {"id": 13, "subject": "Task 8: Workout commentary generator + job", "status": "completed", "blockedBy": [12]},
+    {"id": 14, "subject": "Task 9: Red flags + daily commentary", "status": "completed", "blockedBy": [12]},
+    {"id": 15, "subject": "Task 10: Weekly review generator + job", "status": "completed", "blockedBy": [12]},
+    {"id": 16, "subject": "Task 11: End-to-end verification + staged rollout", "status": "in_progress", "note": "Local verification complete (one-shot sync, commentary, weekly review all verified against real Notion). Remaining: Render env vars, merge PR #27, deploy, enable evening jobs after a clean day.", "blockedBy": [13, 14, 15]}
   ],
   "lastUpdated": "2026-06-12"
 }

--- a/docs/superpowers/specs/2026-06-12-notion-training-sync-design.md
+++ b/docs/superpowers/specs/2026-06-12-notion-training-sync-design.md
@@ -1,0 +1,195 @@
+# Notion Training Sync — Design
+
+Date: 2026-06-12
+Status: Approved by Jules (sections 1–3 approved in brainstorming session)
+
+## Context
+
+Jules is training for the SF Half Marathon (race day: 2026-07-26) using a Runna
+plan, with Claude iOS as a daily coach. Three Notion databases under the
+"SF Half Marathon 2026" page track training:
+
+- **Daily Logs** (data source `78d04a40-94e2-49e7-9199-7647f9f185bb`) — one row
+  per day: weight, sleep, HRV, RHR, calories, macros, mood, red flags, notes.
+  Titles like `Thu Jun 11 (W6 D4) - Rest`.
+- **Workouts** (data source `ffb81591-e4b5-4204-bd12-45d939757458`) — **plan-first**:
+  the full Runna plan is pre-seeded as rows with `Status: Planned`, titles like
+  `W1 Fri - 5km Easy Run`. Completed sessions get actuals filled in and
+  `Status: Done`.
+- **Weekly Reviews** (data source `a36524f3-9afd-4cf9-8be1-d0bf0b2c21fb`) — one
+  row per training week: aggregates plus narrative (What Worked / What Broke /
+  Adjustment for Next Week / Status).
+
+Today Claude iOS manually extracts Apple Health data and updates these — slow
+and manual. Signals already receives Apple Health data automatically via
+webhook (`POST /api/v1/health_data` → `HealthDataProcessor` →
+`health_metrics` + `workouts` tables) and runs Solid Queue (in Puma, on
+Render) with recurring tasks in `config/recurring.yml`. Signals also already
+makes LLM calls via the `ruby_llm` gem (`PlanSuggestionGenerator`,
+`PlanAdherenceGenerator` patterns), and stores the Runna plan in
+`plans.content`.
+
+## Goal
+
+Keep all three Notion databases up to date automatically — data fields fresh
+throughout the day, LLM commentary after workouts and at end of day, weekly
+review on Sunday evenings — with no dependency on Claude iOS sessions, the
+laptop, or MCP. Claude iOS chats remain purely conversational. Runs until at
+least race day with no babysitting.
+
+## Decisions made
+
+- **Lives in Signals** (Rails), not Claude Code / scheduled agents. Zero new
+  infrastructure; runs server-side 24/7.
+- **No MCP server** for the sync. Signals talks to the Notion REST API
+  directly with an internal integration token. (An MCP read interface for
+  Claude iOS chats is a possible later enhancement, out of scope here.)
+- **Full automation** including LLM commentary (not data-only).
+- **Commentary cadence:** workout commentary once when a workout first syncs;
+  daily log commentary in a ~10pm pass; weekly review Sunday ~9pm.
+- **Daily commentary destination:** the `Notes` property of the Daily Logs row
+  (page body untouched). Workout `Notes` remains human-owned.
+- **Alcohol:** convert grams → drinks as `alcohol_g / 14`, rounded to nearest
+  0.5.
+- **Red Flags (daily):** automation auto-sets only the data-computable flags
+  (`RHR up`, `HRV down`, `Sleep <6.5h`, `Weight loss too fast`) against a
+  7-day baseline, **merge-only** — it never removes flags a human set.
+
+## Architecture
+
+```
+Apple Health export (phone)
+        │  POST /api/v1/health_data            (existing)
+        ▼
+HealthDataProcessor                             (existing)
+        │  on success, enqueues ───────────────► NotionSyncJob        (new)
+        ▼                                            │
+health_metrics / workouts tables                     ▼
+                                               Notion::Client (new) ──► Notion REST API
+
+config/recurring.yml additions:
+  notion_catchup        — every 30 min: re-sync rolling window (safety net)
+  daily_log_commentary  — daily ~10pm PT: LLM narrative → Daily Logs Notes
+  weekly_review         — Sunday ~9pm PT: create + fill Weekly Reviews row
+```
+
+### Components (all new, in Signals)
+
+| Component | Responsibility |
+|---|---|
+| `Notion::Client` (`app/services/notion/client.rb`) | Minimal Notion REST wrapper: `query_data_source`, `create_page`, `update_page`. `Net::HTTP`, no new gem. Auth via `NOTION_API_TOKEN`. |
+| `Notion::DailyLogSync` | Upsert daily log row for a date (find by `Date` property, create with generated title if missing); write data fields only. |
+| `Notion::WorkoutSync` | Match an Apple Health workout to a `Planned` Notion row (by PT date + type); fill actuals, set `Status: Done`; create row if unmatched; persist `notion_page_id` on the `workouts` record. Chains `WorkoutCommentaryJob` on first sync. |
+| `NotionSyncJob` (Solid Queue) | Orchestrates DailyLogSync + WorkoutSync for the rolling window. Enqueued by webhook success and by `notion_catchup`. |
+| `Notion::WorkoutCommentaryGenerator` + `WorkoutCommentaryJob` | One `RubyLLM.chat` call (PlanSuggestionGenerator pattern); context: the workout, plan content, recent training. Writes commentary. Runs once per workout. |
+| `Notion::DailyLogCommentaryGenerator` + job | ~10pm PT: builds full-day context (metrics, food, workouts, plan), writes narrative to the row's `Notes`; computes + merges data-computable Red Flags. |
+| `Notion::WeeklyReviewGenerator` + job | Sunday ~9pm PT: computes aggregates from DB, sums `Planned km` from that week's planned Notion rows, LLM writes Status / What Worked / What Broke / Adjustment / Red Flags Triggered. |
+
+## Field mapping & ownership
+
+Rule: **every Notion property has exactly one owner — automation or human.
+The sync never includes human-owned properties in any write payload.** This
+makes all re-syncs safe.
+
+### Daily Logs (upsert by `Date`)
+
+| Property | Owner | Source |
+|---|---|---|
+| Day (title) | automation (on create only) | `Thu Jun 12 (W6 D5) - <Day Type>`; week/day numbering derived from `TRAINING_WEEK1_START` |
+| Date | automation | PT date |
+| Weight (kg), Sleep Hours, HRV, RHR | automation | `health_metrics` (latest value for the date; sleep summed if needed) |
+| Calories Burned | automation | `health_metrics` (active + basal energy for the date) |
+| Calories Actual, Protein (g), Fat (g), Carbs (g) | automation | `food_logs` daily totals |
+| Alcohol (drinks) | automation | `food_logs` alcohol grams ÷ 14, rounded to 0.5 |
+| Calories Target | automation | `nutrition_profiles.calorie_target` |
+| Deficit | automation | computed: Calories Actual − Calories Burned |
+| Day Type | automation | from matched workout type(s); `Rest` if none |
+| Notes | automation (commentary) | end-of-day LLM narrative |
+| Red Flags | shared, merge-only | automation adds `RHR up`, `HRV down`, `Sleep <6.5h`, `Weight loss too fast` when thresholds trip vs 7-day baseline; never removes |
+| Mood, Sleep Score, Withdrawal Bleed | human | never touched |
+
+### Workouts (match-and-fill)
+
+Matching: Apple Health workout → `Planned`/`Modified` Notion row with same PT
+date and compatible type. Matched `notion_page_id` stored on `workouts` row;
+subsequent syncs use the stored ID. Unmatched workouts (golf, unplanned
+strength, etc.) create a new row with `Status: Done`.
+
+| Property | Owner | Source |
+|---|---|---|
+| Actual Distance (km) | automation | `workouts.distance` (converted to km) |
+| Actual Duration (min) | automation | `workouts.duration` / 60 |
+| Actual Avg HR | automation | `workouts.metadata` avg HR if present |
+| Actual Avg Pace | automation | computed `duration / distance`, formatted mm:ss/km |
+| kCal Burned | automation | `workouts.energy_burned` |
+| Status | automation | → `Done` on match/create (never overwrites `Skipped`) |
+| Date, Session (title), Type, Week, Planned * | human/pre-seeded | set on create for unmatched workouts only |
+| Felt, RPE, Fueled Properly, Hit Prescribed Pace, Notes | human | never touched |
+
+Workout commentary (LLM, once per workout): appended to the workout page
+body — `Notes` is human-owned here.
+
+### Weekly Reviews (created Sunday evening)
+
+| Property | Owner | Source |
+|---|---|---|
+| Week (title), Week Number, Week Start | automation | from `TRAINING_WEEK1_START` |
+| Actual km, Long Run Distance (km) | automation | `workouts` aggregates for the week |
+| Planned km | automation | summed from that week's planned Notion workout rows |
+| Quality Session Done, Strength Done | automation | from week's workouts |
+| Avg HRV, Avg RHR, Avg Sleep Hours | automation | `health_metrics` weekly averages |
+| Weight Start (kg), Weight End (kg) | automation | first/last weight of the week |
+| Status, What Worked, What Broke, Adjustment for Next Week, Red Flags Triggered | automation (LLM) | weekly review generator |
+
+## Plumbing
+
+- **Migration:** add `notion_page_id` (string, nullable, indexed) to `workouts`.
+- **Env vars (Render):** `NOTION_API_TOKEN`, `NOTION_DAILY_LOGS_DS_ID`,
+  `NOTION_WORKOUTS_DS_ID`, `NOTION_WEEKLY_REVIEWS_DS_ID`,
+  `TRAINING_WEEK1_START`.
+- **Notion auth setup (manual, one-time):** create an internal integration at
+  notion.so/my-integrations; share the three databases with it; put its token
+  in Render.
+- **Timezone:** all date bucketing in `America/Los_Angeles`.
+- **Rolling window:** sync touches today + yesterday (PT) only — historical
+  pages never churn.
+- Daily/weekly page lookup is a Notion data-source query by date property —
+  no local lookup table (single-user volume).
+
+## Error handling
+
+- Services follow the existing pattern: rescue, `Rails.logger.error`, return
+  `Result` struct. Solid Queue retries transient failures; persistent ones are
+  visible in `solid_queue_failed_executions`.
+- All writes idempotent (upsert by date / `notion_page_id`; merge-only
+  multi-selects), so retries and the 30-min catch-up are always safe.
+- Commentary jobs are independent of data sync jobs — LLM failure cannot block
+  data freshness.
+- Notion rate limits (~3 req/s) are far above this workload; no throttling
+  logic needed.
+
+## Testing
+
+- Minitest unit tests with a stubbed `Notion::Client`:
+  - grams→drinks conversion and rounding
+  - planned-row matching by date + type (incl. no-match → create)
+  - merge-only Red Flags behavior
+  - week/day numbering from `TRAINING_WEEK1_START`
+  - human-owned properties never appear in write payloads
+- Manual end-to-end before enabling schedules: one-shot `rails runner` sync of
+  a single day against the real databases, verified by eye in Notion.
+
+## Rollout
+
+1. Ship with recurring tasks commented out.
+2. Run one-shot sync; verify in Notion.
+3. Enable `notion_catchup` (30-min).
+4. After a clean day, enable webhook-chained `NotionSyncJob` and the evening
+   commentary + weekly review tasks.
+5. Post-race: delete the recurring entries (or keep for the next race).
+
+## Out of scope
+
+- MCP server / read API for Claude iOS chats (possible follow-up).
+- Multi-user support — hardcoded to the single user, per project convention.
+- Backfilling historical Notion pages.

--- a/docs/superpowers/specs/2026-06-12-notion-training-sync-design.md
+++ b/docs/superpowers/specs/2026-06-12-notion-training-sync-design.md
@@ -77,13 +77,13 @@ config/recurring.yml additions:
 
 | Component | Responsibility |
 |---|---|
-| `Notion::Client` (`app/services/notion/client.rb`) | Minimal Notion REST wrapper: `query_data_source`, `create_page`, `update_page`. `Net::HTTP`, no new gem. Auth via `NOTION_API_TOKEN`. |
+| `Notion::Client` (`app/services/notion/client.rb`) | Minimal Notion REST wrapper: `query_data_source`, `create_page`, `update_page`, `append_blocks` (for page-body commentary). `Net::HTTP`, no new gem. Auth via `NOTION_API_TOKEN`. |
 | `Notion::DailyLogSync` | Upsert daily log row for a date (find by `Date` property, create with generated title if missing); write data fields only. |
 | `Notion::WorkoutSync` | Match an Apple Health workout to a `Planned` Notion row (by PT date + type); fill actuals, set `Status: Done`; create row if unmatched; persist `notion_page_id` on the `workouts` record. Chains `WorkoutCommentaryJob` on first sync. |
 | `NotionSyncJob` (Solid Queue) | Orchestrates DailyLogSync + WorkoutSync for the rolling window. Enqueued by webhook success and by `notion_catchup`. |
-| `Notion::WorkoutCommentaryGenerator` + `WorkoutCommentaryJob` | One `RubyLLM.chat` call (PlanSuggestionGenerator pattern); context: the workout, plan content, recent training. Writes commentary. Runs once per workout. |
+| `Notion::WorkoutCommentaryGenerator` + `WorkoutCommentaryJob` | One `RubyLLM.chat` call (PlanSuggestionGenerator pattern); context: the workout, plan content, recent training. Appends commentary to the workout page body via `append_blocks`. Gate: chained only when `WorkoutSync` sets `notion_page_id` from nil → present, so it runs once per workout. (A permanently failed job never re-fires — accepted for single-user.) |
 | `Notion::DailyLogCommentaryGenerator` + job | ~10pm PT: builds full-day context (metrics, food, workouts, plan), writes narrative to the row's `Notes`; computes + merges data-computable Red Flags. |
-| `Notion::WeeklyReviewGenerator` + job | Sunday ~9pm PT: computes aggregates from DB, sums `Planned km` from that week's planned Notion rows, LLM writes Status / What Worked / What Broke / Adjustment / Red Flags Triggered. |
+| `Notion::WeeklyReviewGenerator` + job | Sunday ~9pm PT: upserts the row by `Week Start` (query first, create only if missing — a retry can't duplicate); computes aggregates from DB, sums `Planned km` from that week's planned Notion rows, LLM writes Status / What Worked / What Broke / Adjustment / Red Flags Triggered. |
 
 ## Field mapping & ownership
 
@@ -117,7 +117,7 @@ strength, etc.) create a new row with `Status: Done`.
 
 | Property | Owner | Source |
 |---|---|---|
-| Actual Distance (km) | automation | `workouts.distance` (converted to km) |
+| Actual Distance (km) | automation | `workouts.distance` converted to km using `workouts.distance_units` (never assume a fixed unit) |
 | Actual Duration (min) | automation | `workouts.duration` / 60 |
 | Actual Avg HR | automation | `workouts.metadata` avg HR if present |
 | Actual Avg Pace | automation | computed `duration / distance`, formatted mm:ss/km |

--- a/test/controllers/api/v1/health_data_controller_test.rb
+++ b/test/controllers/api/v1/health_data_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Api::V1::HealthDataControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     @user = User.find_or_create_by!(email: "jules@julescoleman.com") do |u|
       u.password = "password123!"
@@ -70,5 +72,23 @@ class Api::V1::HealthDataControllerTest < ActionDispatch::IntegrationTest
 
     assert @user.workouts.count > 0
     assert @user.health_metrics.count > 0
+  end
+
+  test "enqueues NotionSyncJob on successful payload" do
+    assert_enqueued_with(job: NotionSyncJob) do
+      post api_v1_health_data_path,
+        params: @payload,
+        headers: {"Authorization" => "Bearer #{@token}"},
+        as: :json
+    end
+  end
+
+  test "does not enqueue NotionSyncJob on failed payload" do
+    assert_no_enqueued_jobs(only: NotionSyncJob) do
+      post api_v1_health_data_path,
+        params: {data: {metrics: "bad"}},
+        headers: {"Authorization" => "Bearer #{@token}"},
+        as: :json
+    end
   end
 end

--- a/test/jobs/daily_log_commentary_job_test.rb
+++ b/test/jobs/daily_log_commentary_job_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class DailyLogCommentaryJobTest < ActiveJob::TestCase
+  setup do
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    @orig_training_week1_start = ENV["TRAINING_WEEK1_START"]
+    @orig_notion_daily_logs_ds_id = ENV["NOTION_DAILY_LOGS_DS_ID"]
+
+    ENV["NOTION_API_TOKEN"] = "test-token"
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+
+    @user = users(:one)
+    @user.update!(email: "jules@julescoleman.com")
+  end
+
+  teardown do
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+    ENV["TRAINING_WEEK1_START"] = @orig_training_week1_start
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = @orig_notion_daily_logs_ds_id
+  end
+
+  test "perform calls the generator with the hardcoded user and today's date" do
+    called_with_user = nil
+    called_with_date = nil
+    success_result = Notion::DailyLogCommentaryGenerator::Result.new(
+      success: true, narrative: "Good day.", flags: []
+    )
+
+    orig_call = Notion::DailyLogCommentaryGenerator.method(:call)
+    Notion::DailyLogCommentaryGenerator.define_singleton_method(:call) do |user, date:, **_|
+      called_with_user = user
+      called_with_date = date
+      success_result
+    end
+
+    DailyLogCommentaryJob.perform_now
+
+    assert_equal @user.id, called_with_user.id
+    assert_equal Notion::TrainingWeek.today, called_with_date
+  ensure
+    Notion::DailyLogCommentaryGenerator.define_singleton_method(:call, orig_call)
+  end
+
+  test "failure path logs without raising" do
+    failure_result = Notion::DailyLogCommentaryGenerator::Result.new(
+      success: false, error: "something went wrong"
+    )
+
+    orig_call = Notion::DailyLogCommentaryGenerator.method(:call)
+    Notion::DailyLogCommentaryGenerator.define_singleton_method(:call) do |user, date:, **_|
+      failure_result
+    end
+
+    assert_nothing_raised do
+      DailyLogCommentaryJob.perform_now
+    end
+  ensure
+    Notion::DailyLogCommentaryGenerator.define_singleton_method(:call, orig_call)
+  end
+end

--- a/test/jobs/notion_sync_job_test.rb
+++ b/test/jobs/notion_sync_job_test.rb
@@ -44,10 +44,43 @@ class NotionSyncJobTest < ActiveJob::TestCase
     NotionSyncJob.perform_now
 
     today = Notion::TrainingWeek.today
+    assert_equal 4, calls.size
     assert_equal [:workout, today - 1], calls[0]
     assert_equal [:daily, today - 1, "Easy Run"], calls[1]
     assert_equal [:workout, today], calls[2]
+    assert_equal [:daily, today, "Easy Run"], calls[3]
     assert_enqueued_with(job: WorkoutCommentaryJob, args: [42])
+  ensure
+    Notion::WorkoutSync.define_singleton_method(:call, orig_workout_call)
+    Notion::DailyLogSync.define_singleton_method(:call, orig_daily_call)
+  end
+
+  test "raises after processing both dates when WorkoutSync fails, still calls DailyLogSync for both" do
+    daily_calls = []
+    failed_workout_result = Notion::WorkoutSync::Result.new(
+      success: false, error: "boom", newly_synced_workout_ids: [], day_type: nil
+    )
+    daily_result = Notion::DailyLogSync::Result.new(success: true, page_id: "p", created: false)
+
+    orig_workout_call = Notion::WorkoutSync.method(:call)
+    orig_daily_call = Notion::DailyLogSync.method(:call)
+
+    Notion::WorkoutSync.define_singleton_method(:call) do |user, date:, client:|
+      failed_workout_result
+    end
+    Notion::DailyLogSync.define_singleton_method(:call) do |user, date:, day_type:, client:|
+      daily_calls << date
+      daily_result
+    end
+
+    assert_raises(RuntimeError, /NotionSyncJob partial failure/) do
+      NotionSyncJob.perform_now
+    end
+
+    today = Notion::TrainingWeek.today
+    assert_equal 2, daily_calls.size, "DailyLogSync should be called for both dates even on partial failure"
+    assert_includes daily_calls, today - 1
+    assert_includes daily_calls, today
   ensure
     Notion::WorkoutSync.define_singleton_method(:call, orig_workout_call)
     Notion::DailyLogSync.define_singleton_method(:call, orig_daily_call)

--- a/test/jobs/notion_sync_job_test.rb
+++ b/test/jobs/notion_sync_job_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+require_relative "../services/notion/fake_notion_client"
+
+class NotionSyncJobTest < ActiveJob::TestCase
+  setup do
+    @orig_week1_start = ENV["TRAINING_WEEK1_START"]
+    @orig_daily_ds_id = ENV["NOTION_DAILY_LOGS_DS_ID"]
+    @orig_workouts_ds_id = ENV["NOTION_WORKOUTS_DS_ID"]
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+    ENV["NOTION_WORKOUTS_DS_ID"] = "ds-workouts"
+    ENV["NOTION_API_TOKEN"] = "test-token"
+    @user = users(:one)
+    @user.update!(email: "jules@julescoleman.com")
+  end
+
+  teardown do
+    ENV["TRAINING_WEEK1_START"] = @orig_week1_start
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = @orig_daily_ds_id
+    ENV["NOTION_WORKOUTS_DS_ID"] = @orig_workouts_ds_id
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+  end
+
+  test "syncs workouts then daily log for yesterday and today, enqueues commentary for new syncs" do
+    calls = []
+    workout_result = Notion::WorkoutSync::Result.new(
+      success: true, newly_synced_workout_ids: [42], day_type: "Easy Run"
+    )
+    daily_result = Notion::DailyLogSync::Result.new(success: true, page_id: "p", created: false)
+
+    orig_workout_call = Notion::WorkoutSync.method(:call)
+    orig_daily_call = Notion::DailyLogSync.method(:call)
+
+    Notion::WorkoutSync.define_singleton_method(:call) do |user, date:, client:|
+      calls << [:workout, date]
+      workout_result
+    end
+    Notion::DailyLogSync.define_singleton_method(:call) do |user, date:, day_type:, client:|
+      calls << [:daily, date, day_type]
+      daily_result
+    end
+
+    NotionSyncJob.perform_now
+
+    today = Notion::TrainingWeek.today
+    assert_equal [:workout, today - 1], calls[0]
+    assert_equal [:daily, today - 1, "Easy Run"], calls[1]
+    assert_equal [:workout, today], calls[2]
+    assert_enqueued_with(job: WorkoutCommentaryJob, args: [42])
+  ensure
+    Notion::WorkoutSync.define_singleton_method(:call, orig_workout_call)
+    Notion::DailyLogSync.define_singleton_method(:call, orig_daily_call)
+  end
+end

--- a/test/jobs/notion_sync_job_test.rb
+++ b/test/jobs/notion_sync_job_test.rb
@@ -55,7 +55,7 @@ class NotionSyncJobTest < ActiveJob::TestCase
     Notion::DailyLogSync.define_singleton_method(:call, orig_daily_call)
   end
 
-  test "raises after processing both dates when WorkoutSync fails, still calls DailyLogSync for both" do
+  test "retries after processing both dates when WorkoutSync fails, still calls DailyLogSync for both" do
     daily_calls = []
     failed_workout_result = Notion::WorkoutSync::Result.new(
       success: false, error: "boom", newly_synced_workout_ids: [], day_type: nil
@@ -73,7 +73,9 @@ class NotionSyncJobTest < ActiveJob::TestCase
       daily_result
     end
 
-    assert_raises(RuntimeError, /NotionSyncJob partial failure/) do
+    # The partial-failure raise is a Notion::Client::Error, which retry_on
+    # intercepts and re-enqueues rather than letting it propagate.
+    assert_enqueued_with(job: NotionSyncJob) do
       NotionSyncJob.perform_now
     end
 

--- a/test/jobs/weekly_review_job_test.rb
+++ b/test/jobs/weekly_review_job_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class WeeklyReviewJobTest < ActiveJob::TestCase
+  setup do
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    @orig_training_week1_start = ENV["TRAINING_WEEK1_START"]
+    @orig_notion_weekly_reviews_ds_id = ENV["NOTION_WEEKLY_REVIEWS_DS_ID"]
+    @orig_notion_workouts_ds_id = ENV["NOTION_WORKOUTS_DS_ID"]
+    @orig_notion_daily_logs_ds_id = ENV["NOTION_DAILY_LOGS_DS_ID"]
+
+    ENV["NOTION_API_TOKEN"] = "test-token"
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_WEEKLY_REVIEWS_DS_ID"] = "ds-weekly"
+    ENV["NOTION_WORKOUTS_DS_ID"] = "ds-workouts"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+
+    @user = users(:one)
+    @user.update!(email: "jules@julescoleman.com")
+  end
+
+  teardown do
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+    ENV["TRAINING_WEEK1_START"] = @orig_training_week1_start
+    ENV["NOTION_WEEKLY_REVIEWS_DS_ID"] = @orig_notion_weekly_reviews_ds_id
+    ENV["NOTION_WORKOUTS_DS_ID"] = @orig_notion_workouts_ds_id
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = @orig_notion_daily_logs_ds_id
+  end
+
+  test "perform calls the generator with the hardcoded user and today's date" do
+    called_with_user = nil
+    called_with_date = nil
+    success_result = Notion::WeeklyReviewGenerator::Result.new(
+      success: true, page_id: "page-1", created: true
+    )
+
+    orig_call = Notion::WeeklyReviewGenerator.method(:call)
+    Notion::WeeklyReviewGenerator.define_singleton_method(:call) do |user, date:, **_|
+      called_with_user = user
+      called_with_date = date
+      success_result
+    end
+
+    WeeklyReviewJob.perform_now
+
+    assert_equal @user.id, called_with_user.id
+    assert_equal Notion::TrainingWeek.today, called_with_date
+  ensure
+    Notion::WeeklyReviewGenerator.define_singleton_method(:call, orig_call)
+  end
+
+  test "failure path logs without raising" do
+    failure_result = Notion::WeeklyReviewGenerator::Result.new(
+      success: false, error: "something went wrong"
+    )
+
+    orig_call = Notion::WeeklyReviewGenerator.method(:call)
+    Notion::WeeklyReviewGenerator.define_singleton_method(:call) do |user, date:, **_|
+      failure_result
+    end
+
+    assert_nothing_raised do
+      WeeklyReviewJob.perform_now
+    end
+  ensure
+    Notion::WeeklyReviewGenerator.define_singleton_method(:call, orig_call)
+  end
+end

--- a/test/jobs/workout_commentary_job_test.rb
+++ b/test/jobs/workout_commentary_job_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class WorkoutCommentaryJobTest < ActiveJob::TestCase
+  setup do
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    ENV["NOTION_API_TOKEN"] = "test-token"
+
+    @user = users(:one)
+    @workout = @user.workouts.create!(
+      external_id: "commentary-job-test-#{SecureRandom.hex(4)}",
+      workout_type: "Running",
+      started_at: 1.day.ago,
+      ended_at: 1.day.ago + 30.minutes,
+      duration: 1800,
+      notion_page_id: "notion-page-job-test"
+    )
+  end
+
+  teardown do
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+  end
+
+  test "perform calls the generator with the workout" do
+    called_with = nil
+    success_result = Notion::WorkoutCommentaryGenerator::Result.new(success: true, commentary: "Great run!")
+
+    orig_call = Notion::WorkoutCommentaryGenerator.method(:call)
+    Notion::WorkoutCommentaryGenerator.define_singleton_method(:call) do |workout, **_|
+      called_with = workout
+      success_result
+    end
+
+    WorkoutCommentaryJob.perform_now(@workout.id)
+
+    assert_equal @workout.id, called_with.id
+  ensure
+    Notion::WorkoutCommentaryGenerator.define_singleton_method(:call, orig_call)
+  end
+
+  test "failure path logs without raising" do
+    failure_result = Notion::WorkoutCommentaryGenerator::Result.new(success: false, error: "something went wrong")
+
+    orig_call = Notion::WorkoutCommentaryGenerator.method(:call)
+    Notion::WorkoutCommentaryGenerator.define_singleton_method(:call) do |workout, **_|
+      failure_result
+    end
+
+    assert_nothing_raised do
+      WorkoutCommentaryJob.perform_now(@workout.id)
+    end
+  ensure
+    Notion::WorkoutCommentaryGenerator.define_singleton_method(:call, orig_call)
+  end
+end

--- a/test/services/notion/client_test.rb
+++ b/test/services/notion/client_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class Notion::ClientTest < ActiveSupport::TestCase
+  setup do
+    @client = Notion::Client.new(token: "secret")
+    @calls = []
+    calls = @calls
+    @responses = []
+    responses = @responses
+    @client.define_singleton_method(:request) do |method, path, body|
+      calls << [method, path, body]
+      responses.shift || {"results" => [], "has_more" => false}
+    end
+  end
+
+  test "query_data_source posts filter and paginates" do
+    @responses << {"results" => [{"id" => "p1"}], "has_more" => true, "next_cursor" => "abc"}
+    @responses << {"results" => [{"id" => "p2"}], "has_more" => false}
+
+    filter = {"property" => "Date", "date" => {"equals" => "2026-06-12"}}
+    results = @client.query_data_source("ds-1", filter: filter)
+
+    assert_equal %w[p1 p2], results.map { |r| r["id"] }
+    assert_equal [:post, "/data_sources/ds-1/query", {"filter" => filter}], @calls[0]
+    assert_equal "abc", @calls[1][2]["start_cursor"]
+  end
+
+  test "create_page targets data source parent and includes children when given" do
+    @responses << {"id" => "new-page"}
+    @client.create_page(data_source_id: "ds-1", properties: {"Day" => {}}, children: [{"type" => "paragraph"}])
+
+    method, path, body = @calls[0]
+    assert_equal :post, method
+    assert_equal "/pages", path
+    assert_equal({"type" => "data_source_id", "data_source_id" => "ds-1"}, body["parent"])
+    assert body.key?("children")
+  end
+
+  test "update_page patches properties" do
+    @responses << {"id" => "p1"}
+    @client.update_page("p1", properties: {"RHR" => {"number" => 52}})
+    assert_equal [:patch, "/pages/p1", {"properties" => {"RHR" => {"number" => 52}}}], @calls[0]
+  end
+
+  test "append_blocks patches block children" do
+    @responses << {"results" => []}
+    @client.append_blocks("p1", children: [{"type" => "paragraph"}])
+    assert_equal :patch, @calls[0][0]
+    assert_equal "/blocks/p1/children", @calls[0][1]
+  end
+end

--- a/test/services/notion/client_test.rb
+++ b/test/services/notion/client_test.rb
@@ -48,4 +48,25 @@ class Notion::ClientTest < ActiveSupport::TestCase
     assert_equal :patch, @calls[0][0]
     assert_equal "/blocks/p1/children", @calls[0][1]
   end
+
+  test "request raises Error with raw body snippet when response is non-2xx with non-JSON body" do
+    raw_client = Notion::Client.new(token: "secret")
+
+    fake_response = Net::HTTPBadGateway.new("1.1", "502", "Bad Gateway")
+    fake_response.define_singleton_method(:body) { "<html>oops</html>" }
+
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) { |_req| fake_response }
+
+    original_start = Net::HTTP.method(:start)
+    Net::HTTP.define_singleton_method(:start) { |*_args, **_opts, &blk| blk.call(fake_http) }
+
+    error = assert_raises(Notion::Client::Error) do
+      raw_client.update_page("p1", properties: {})
+    end
+    assert_includes error.message, "502"
+    assert_includes error.message, "oops"
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
 end

--- a/test/services/notion/daily_log_commentary_generator_test.rb
+++ b/test/services/notion/daily_log_commentary_generator_test.rb
@@ -1,0 +1,160 @@
+require "test_helper"
+require_relative "fake_notion_client"
+require_relative "../../support/llm_stubbing"
+
+class Notion::DailyLogCommentaryGeneratorTest < ActiveSupport::TestCase
+  include LlmStubbing
+
+  DATE = Date.new(2026, 6, 12)
+
+  setup do
+    @orig_llm_model = ENV["LLM_MODEL"]
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    @orig_training_week1_start = ENV["TRAINING_WEEK1_START"]
+    @orig_notion_daily_logs_ds_id = ENV["NOTION_DAILY_LOGS_DS_ID"]
+
+    ENV["LLM_MODEL"] = "gpt-5-nano"
+    ENV["NOTION_API_TOKEN"] = "test-token"
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+
+    @user = users(:one)
+    @fake_response = Data.define(:content).new(content: "Today was a solid training day.")
+  end
+
+  teardown do
+    ENV["LLM_MODEL"] = @orig_llm_model
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+    ENV["TRAINING_WEEK1_START"] = @orig_training_week1_start
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = @orig_notion_daily_logs_ds_id
+  end
+
+  def existing_page(id: "page-daily-1", red_flags: [])
+    flag_data = red_flags.map { |f| {"name" => f} }
+    {
+      "id" => id,
+      "properties" => {
+        "Red Flags" => {"multi_select" => flag_data},
+        "Notes" => {"rich_text" => []}
+      }
+    }
+  end
+
+  # (a) writes Notes with LLM text and merges red flags
+  test "writes Notes with LLM narrative and merges existing and computed red flags" do
+    # Page exists with existing human flag "Low mood"
+    page = existing_page(red_flags: ["Low mood"])
+    client = FakeNotionClient.new(query_results: [[page]])
+
+    # Seed RHR data so RedFlagDetector computes "RHR up"
+    tz = ActiveSupport::TimeZone["America/Los_Angeles"]
+    (1..3).each do |i|
+      @user.health_metrics.create!(
+        metric_name: "resting_heart_rate", value: 50, units: "bpm",
+        recorded_at: tz.local(DATE.year, DATE.month, DATE.day, 12) - i.days
+      )
+    end
+    @user.health_metrics.create!(
+      metric_name: "resting_heart_rate", value: 55, units: "bpm",
+      recorded_at: tz.local(DATE.year, DATE.month, DATE.day, 12)
+    )
+
+    stub_llm_chat(@fake_response) do
+      result = Notion::DailyLogCommentaryGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      assert_equal "Today was a solid training day.", result.narrative
+      assert_equal 1, client.updates.size
+
+      update = client.updates.first
+      assert_equal "page-daily-1", update[:page_id]
+
+      # Notes contains LLM text
+      notes_content = update[:properties]["Notes"]["rich_text"].first["text"]["content"]
+      assert_equal "Today was a solid training day.", notes_content
+
+      # Red Flags merges both "Low mood" (existing) and "RHR up" (computed)
+      flag_names = update[:properties]["Red Flags"]["multi_select"].map { |f| f["name"] }
+      assert_includes flag_names, "Low mood"
+      assert_includes flag_names, "RHR up"
+    end
+  end
+
+  # (b) never removes existing flags
+  test "never removes existing flags even when computed flags are empty" do
+    page = existing_page(red_flags: ["Low mood", "Sleep <6.5h"])
+    client = FakeNotionClient.new(query_results: [[page]])
+
+    # No health metrics → no computed flags
+    stub_llm_chat(@fake_response) do
+      result = Notion::DailyLogCommentaryGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      update = client.updates.first
+
+      # Red Flags should retain existing flags (merged = same as existing, so may not be in payload)
+      # The implementation skips the Red Flags key when merged == existing.sort
+      # Let's verify either Red Flags is absent (no-op) or still contains both flags.
+      if update[:properties].key?("Red Flags")
+        flag_names = update[:properties]["Red Flags"]["multi_select"].map { |f| f["name"] }
+        assert_includes flag_names, "Low mood"
+        assert_includes flag_names, "Sleep <6.5h"
+      end
+      # Either way, the Notes should still be written
+      assert update[:properties].key?("Notes")
+    end
+  end
+
+  # (c) creates the daily page first when missing
+  test "creates the daily page via DailyLogSync when page is missing then writes to it" do
+    # First query returns empty (page missing), after DailyLogSync creates it, second query returns it
+    created_page = existing_page(id: "created-1", red_flags: [])
+    client = FakeNotionClient.new(query_results: [[], [created_page]])
+
+    # Stub DailyLogSync.call to simulate page creation
+    orig_call = Notion::DailyLogSync.method(:call)
+    Notion::DailyLogSync.define_singleton_method(:call) do |user, date:, client:|
+      Notion::DailyLogSync::Result.new(success: true, page_id: "created-1", created: true)
+    end
+
+    stub_llm_chat(@fake_response) do
+      result = Notion::DailyLogCommentaryGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      assert_equal 1, client.updates.size
+      assert_equal "created-1", client.updates.first[:page_id]
+    end
+  ensure
+    Notion::DailyLogSync.define_singleton_method(:call, orig_call)
+  end
+
+  # (d) LLM failure → no update call, success false
+  test "LLM failure returns success false and makes no update_page call" do
+    page = existing_page
+    client = FakeNotionClient.new(query_results: [[page]])
+
+    stub_llm_chat_error("LLM timeout") do
+      result = Notion::DailyLogCommentaryGenerator.call(@user, date: DATE, client: client)
+
+      refute result.success
+      assert_equal "LLM timeout", result.error
+      assert_empty client.updates
+    end
+  end
+
+  # Red Flags not included in payload when merged == existing (no-op churn avoidance)
+  test "omits Red Flags from payload when computed flags add nothing new" do
+    page = existing_page(red_flags: [])
+    client = FakeNotionClient.new(query_results: [[page]])
+
+    # No health metrics → no computed flags; existing also empty → merged == existing, no churn
+    stub_llm_chat(@fake_response) do
+      Notion::DailyLogCommentaryGenerator.call(@user, date: DATE, client: client)
+    end
+
+    update = client.updates.first
+    # Notes should still be written, Red Flags should NOT be in payload (no-op)
+    assert update[:properties].key?("Notes")
+    refute update[:properties].key?("Red Flags")
+  end
+end

--- a/test/services/notion/daily_log_sync_test.rb
+++ b/test/services/notion/daily_log_sync_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+require_relative "fake_notion_client"
+
+class Notion::DailyLogSyncTest < ActiveSupport::TestCase
+  DATE = Date.new(2026, 6, 11)
+
+  setup do
+    @user = users(:one)
+    @original_week1_start = ENV["TRAINING_WEEK1_START"]
+    @original_ds_id = ENV["NOTION_DAILY_LOGS_DS_ID"]
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+    noon_pt = ActiveSupport::TimeZone["America/Los_Angeles"].local(2026, 6, 11, 12)
+    @user.health_metrics.create!(metric_name: "weight", value: 61.2, units: "kg", recorded_at: noon_pt)
+    @user.health_metrics.create!(metric_name: "active_energy", value: 500, units: "kcal", recorded_at: noon_pt)
+    @user.health_metrics.create!(metric_name: "basal_energy_burned", value: 1300, units: "kcal", recorded_at: noon_pt)
+    food = @user.foods.create!(description: "test food", kcal: 1, protein: 0, carbs: 0, fat: 0, fibre: 0)
+    @user.food_logs.create!(food: food, consumed_at: noon_pt, kcal: 1650, protein: 140, fat: 50, carbs: 160, fibre: 0, alcohol: 21)
+  end
+
+  teardown do
+    ENV["TRAINING_WEEK1_START"] = @original_week1_start
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = @original_ds_id
+  end
+
+  test "creates page with generated title, date, day type, and data fields when none exists" do
+    client = FakeNotionClient.new(query_results: [[]])
+    result = Notion::DailyLogSync.call(@user, date: DATE, day_type: "Easy Run", client: client)
+
+    assert result.success
+    assert result.created
+    props = client.creates.first[:properties]
+    assert_equal "Thu Jun 11 (W6 D4) - Easy Run", props["Day"]["title"].first["text"]["content"]
+    assert_equal "2026-06-11", props["Date"]["date"]["start"]
+    assert_equal "Easy Run", props["Day Type"]["select"]["name"]
+    assert_equal 61.2, props["Weight (kg)"]["number"]
+    assert_equal 1800.0, props["Calories Burned"]["number"]
+    assert_equal 1650.0, props["Calories Actual"]["number"]
+    assert_equal(-150.0, props["Deficit"]["number"])
+    assert_equal 1.5, props["Alcohol (drinks)"]["number"]  # 21g / 14 = 1.5
+  end
+
+  test "updates existing page without touching human-owned fields or title" do
+    existing = {"id" => "page-1", "properties" => {"Day Type" => {"select" => {"name" => "Rest"}}}}
+    client = FakeNotionClient.new(query_results: [[existing]])
+
+    result = Notion::DailyLogSync.call(@user, date: DATE, day_type: "Long Run", client: client)
+
+    assert result.success
+    refute result.created
+    update = client.updates.first
+    assert_equal "page-1", update[:page_id]
+    props = update[:properties]
+    refute props.key?("Day")
+    refute props.key?("Mood")
+    refute props.key?("Notes")
+    refute props.key?("Red Flags")
+    assert_equal "Long Run", props["Day Type"]["select"]["name"] # Rest -> Long Run upgrade
+  end
+
+  test "does not downgrade or overwrite a human-set day type" do
+    existing = {"id" => "page-1", "properties" => {"Day Type" => {"select" => {"name" => "Travel"}}}}
+    client = FakeNotionClient.new(query_results: [[existing]])
+
+    Notion::DailyLogSync.call(@user, date: DATE, day_type: "Easy Run", client: client)
+
+    refute client.updates.first[:properties].key?("Day Type")
+  end
+
+  test "omits properties with no data" do
+    client = FakeNotionClient.new(query_results: [[]])
+    @user.health_metrics.delete_all
+    @user.food_logs.delete_all
+
+    Notion::DailyLogSync.call(@user, date: DATE, client: client)
+
+    props = client.creates.first[:properties]
+    refute props.key?("Weight (kg)")
+    refute props.key?("Deficit")
+  end
+
+  test "returns failure result on client error" do
+    client = FakeNotionClient.new
+    def client.query_data_source(*) = raise(Notion::Client::Error, "boom")
+
+    result = Notion::DailyLogSync.call(@user, date: DATE, client: client)
+
+    refute result.success
+    assert_match "boom", result.error
+  end
+end

--- a/test/services/notion/daily_log_sync_test.rb
+++ b/test/services/notion/daily_log_sync_test.rb
@@ -56,6 +56,7 @@ class Notion::DailyLogSyncTest < ActiveSupport::TestCase
     refute props.key?("Notes")
     refute props.key?("Red Flags")
     assert_equal "Long Run", props["Day Type"]["select"]["name"] # Rest -> Long Run upgrade
+    assert_equal 61.2, props["Weight (kg)"]["number"]
   end
 
   test "does not downgrade or overwrite a human-set day type" do

--- a/test/services/notion/fake_notion_client.rb
+++ b/test/services/notion/fake_notion_client.rb
@@ -1,0 +1,31 @@
+class FakeNotionClient
+  attr_reader :queries, :creates, :updates, :appends
+
+  def initialize(query_results: [])
+    @query_results = query_results # array of arrays, shifted per call
+    @queries = []
+    @creates = []
+    @updates = []
+    @appends = []
+  end
+
+  def query_data_source(ds_id, filter: nil)
+    @queries << {ds_id: ds_id, filter: filter}
+    @query_results.shift || []
+  end
+
+  def create_page(data_source_id:, properties:, children: nil)
+    @creates << {ds_id: data_source_id, properties: properties, children: children}
+    {"id" => "created-#{@creates.size}", "properties" => properties}
+  end
+
+  def update_page(page_id, properties:)
+    @updates << {page_id: page_id, properties: properties}
+    {"id" => page_id}
+  end
+
+  def append_blocks(page_id, children:)
+    @appends << {page_id: page_id, children: children}
+    {"results" => []}
+  end
+end

--- a/test/services/notion/properties_test.rb
+++ b/test/services/notion/properties_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Notion::PropertiesTest < ActiveSupport::TestCase
+  test "builds title, rich_text, number, date, select, multi_select, checkbox" do
+    assert_equal({"title" => [{"text" => {"content" => "Hi"}}]}, Notion::Properties.title("Hi"))
+    assert_equal({"rich_text" => [{"text" => {"content" => "note"}}]}, Notion::Properties.rich_text("note"))
+    assert_equal({"number" => 7.5}, Notion::Properties.number(7.5))
+    assert_equal({"date" => {"start" => "2026-06-12"}}, Notion::Properties.date(Date.new(2026, 6, 12)))
+    assert_equal({"select" => {"name" => "Easy Run"}}, Notion::Properties.select("Easy Run"))
+    assert_equal({"multi_select" => [{"name" => "RHR up"}, {"name" => "HRV down"}]},
+      Notion::Properties.multi_select(["RHR up", "HRV down"]))
+    assert_equal({"checkbox" => true}, Notion::Properties.checkbox(true))
+  end
+
+  test "rich_text truncates to 2000 chars" do
+    prop = Notion::Properties.rich_text("x" * 3000)
+    assert_equal 2000, prop["rich_text"].first["text"]["content"].length
+  end
+
+  test "reads values from page property JSON" do
+    assert_equal "Planned", Notion::Properties.read_select({"select" => {"name" => "Planned"}})
+    assert_nil Notion::Properties.read_select({"select" => nil})
+    assert_equal ["RHR up"], Notion::Properties.read_multi_select({"multi_select" => [{"name" => "RHR up"}]})
+    assert_equal [], Notion::Properties.read_multi_select(nil)
+    assert_equal 5.0, Notion::Properties.read_number({"number" => 5.0})
+    assert_equal "W1 Fri - 5km Easy Run",
+      Notion::Properties.read_title({"title" => [{"plain_text" => "W1 Fri - 5km Easy Run"}]})
+    assert_equal "2026-06-12", Notion::Properties.read_date({"date" => {"start" => "2026-06-12"}})
+  end
+
+  test "paragraph_block builds a body block and truncates" do
+    block = Notion::Properties.paragraph_block("hello")
+    assert_equal "paragraph", block["type"]
+    assert_equal "hello", block.dig("paragraph", "rich_text", 0, "text", "content")
+  end
+end

--- a/test/services/notion/red_flag_detector_test.rb
+++ b/test/services/notion/red_flag_detector_test.rb
@@ -1,0 +1,145 @@
+require "test_helper"
+
+class Notion::RedFlagDetectorTest < ActiveSupport::TestCase
+  DATE = Date.new(2026, 6, 12)
+
+  setup do
+    @orig_training_week1_start = ENV["TRAINING_WEEK1_START"]
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+
+    @user = users(:one)
+
+    # Helper to record a metric on a given date at noon PT
+    @tz = ActiveSupport::TimeZone["America/Los_Angeles"]
+  end
+
+  teardown do
+    ENV["TRAINING_WEEK1_START"] = @orig_training_week1_start
+  end
+
+  def record(metric_name, value, date = DATE)
+    @user.health_metrics.create!(
+      metric_name: metric_name,
+      value: value,
+      units: "units",
+      recorded_at: @tz.local(date.year, date.month, date.day, 12)
+    )
+  end
+
+  def record_baseline(metric_name, value, days_back:)
+    record(metric_name, value, DATE - days_back)
+  end
+
+  # --- RHR up ---
+
+  test "RHR up flag trips when today >= baseline + 5" do
+    # baseline: 3 readings 1-3 days back, avg 50 bpm
+    record_baseline("resting_heart_rate", 50, days_back: 1)
+    record_baseline("resting_heart_rate", 50, days_back: 2)
+    record_baseline("resting_heart_rate", 50, days_back: 3)
+    # today = 55 (exactly at threshold)
+    record("resting_heart_rate", 55)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    assert_includes flags, "RHR up"
+  end
+
+  test "RHR up flag does not trip when today < baseline + 5" do
+    record_baseline("resting_heart_rate", 50, days_back: 1)
+    record_baseline("resting_heart_rate", 50, days_back: 2)
+    # today = 54 (below threshold)
+    record("resting_heart_rate", 54)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    refute_includes flags, "RHR up"
+  end
+
+  test "RHR baseline ignores today's value" do
+    # Only today's reading — no baseline possible
+    record("resting_heart_rate", 80)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    refute_includes flags, "RHR up"
+  end
+
+  # --- HRV down ---
+
+  test "HRV down flag trips when today <= baseline * 0.8" do
+    # baseline avg = 50ms
+    record_baseline("heart_rate_variability", 50, days_back: 1)
+    record_baseline("heart_rate_variability", 50, days_back: 2)
+    # today = 40 (exactly 80% of 50)
+    record("heart_rate_variability", 40)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    assert_includes flags, "HRV down"
+  end
+
+  test "HRV down flag does not trip when today > baseline * 0.8" do
+    record_baseline("heart_rate_variability", 50, days_back: 1)
+    # today = 41 (above 80% of 50)
+    record("heart_rate_variability", 41)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    refute_includes flags, "HRV down"
+  end
+
+  test "HRV baseline ignores today's value" do
+    record("heart_rate_variability", 10)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    refute_includes flags, "HRV down"
+  end
+
+  # --- Sleep short ---
+
+  test "Sleep <6.5h flag trips when sleep < 6.5" do
+    record("sleep_analysis", 6.0)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    assert_includes flags, "Sleep <6.5h"
+  end
+
+  test "Sleep <6.5h flag does not trip when sleep >= 6.5" do
+    record("sleep_analysis", 6.5)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    refute_includes flags, "Sleep <6.5h"
+  end
+
+  # --- Weight loss too fast ---
+
+  test "Weight loss too fast flag trips when lost > 1 kg vs ~7 days ago" do
+    # ~7 days ago: 65 kg
+    record("weight", 65.0, DATE - 7)
+    # today: 63.9 kg (lost 1.1 kg)
+    record("weight", 63.9)
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    assert_includes flags, "Weight loss too fast"
+  end
+
+  test "Weight loss too fast flag does not trip when loss <= 1 kg" do
+    record("weight", 65.0, DATE - 7)
+    record("weight", 64.1) # lost 0.9 kg
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    refute_includes flags, "Weight loss too fast"
+  end
+
+  test "Weight loss too fast uses nearest reading within 7-9 days back" do
+    # No reading exactly 7 days back, but 8 days back
+    record("weight", 66.0, DATE - 8)
+    record("weight", 64.9) # lost 1.1 kg vs 8 days ago
+
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    assert_includes flags, "Weight loss too fast"
+  end
+
+  # --- No flags with no data ---
+
+  test "returns empty array when no health metrics exist" do
+    flags = Notion::RedFlagDetector.call(@user, date: DATE)
+    assert_equal [], flags
+  end
+end

--- a/test/services/notion/training_week_test.rb
+++ b/test/services/notion/training_week_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Notion::TrainingWeekTest < ActiveSupport::TestCase
+  W1 = Date.new(2026, 5, 4) # Monday
+
+  test "computes week and day numbers" do
+    tw = Notion::TrainingWeek.new(Date.new(2026, 6, 11), week1_start: W1) # known: W6 D4
+    assert_equal 6, tw.week_number
+    assert_equal 4, tw.day_number
+    assert_equal Date.new(2026, 6, 8), tw.week_start
+    assert_equal "W6 D4", tw.label
+  end
+
+  test "first day of plan is W1 D1" do
+    tw = Notion::TrainingWeek.new(W1, week1_start: W1)
+    assert_equal "W1 D1", tw.label
+  end
+
+  test "daily log title format" do
+    tw = Notion::TrainingWeek.new(Date.new(2026, 6, 11), week1_start: W1)
+    assert_equal "Thu Jun 11 (W6 D4) - Rest", tw.daily_title("Rest")
+  end
+
+  test "today returns a date in Pacific time" do
+    assert_instance_of Date, Notion::TrainingWeek.today
+  end
+end

--- a/test/services/notion/weekly_review_generator_test.rb
+++ b/test/services/notion/weekly_review_generator_test.rb
@@ -1,0 +1,269 @@
+require "test_helper"
+require_relative "fake_notion_client"
+require_relative "../../support/llm_stubbing"
+
+class Notion::WeeklyReviewGeneratorTest < ActiveSupport::TestCase
+  include LlmStubbing
+
+  # A Thursday in W6 (week start Mon Jun 8, week end Sun Jun 14)
+  DATE = Date.new(2026, 6, 12)
+  WEEK_START = Date.new(2026, 6, 8)
+  WEEK_END = Date.new(2026, 6, 14)
+
+  setup do
+    @orig_llm_model = ENV["LLM_MODEL"]
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    @orig_training_week1_start = ENV["TRAINING_WEEK1_START"]
+    @orig_notion_weekly_reviews_ds_id = ENV["NOTION_WEEKLY_REVIEWS_DS_ID"]
+    @orig_notion_workouts_ds_id = ENV["NOTION_WORKOUTS_DS_ID"]
+    @orig_notion_daily_logs_ds_id = ENV["NOTION_DAILY_LOGS_DS_ID"]
+
+    ENV["LLM_MODEL"] = "gpt-5-nano"
+    ENV["NOTION_API_TOKEN"] = "test-token"
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_WEEKLY_REVIEWS_DS_ID"] = "ds-weekly"
+    ENV["NOTION_WORKOUTS_DS_ID"] = "ds-workouts"
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = "ds-daily"
+
+    @user = users(:one)
+    @fake_llm_response = Data.define(:content).new(
+      content: '{"status":"On Track","what_worked":"Good mileage.","what_broke":"Nothing.","adjustment_for_next_week":"Keep it up."}'
+    )
+  end
+
+  teardown do
+    ENV["LLM_MODEL"] = @orig_llm_model
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+    ENV["TRAINING_WEEK1_START"] = @orig_training_week1_start
+    ENV["NOTION_WEEKLY_REVIEWS_DS_ID"] = @orig_notion_weekly_reviews_ds_id
+    ENV["NOTION_WORKOUTS_DS_ID"] = @orig_notion_workouts_ds_id
+    ENV["NOTION_DAILY_LOGS_DS_ID"] = @orig_notion_daily_logs_ds_id
+  end
+
+  def workout_row(status:, type:, planned_km: nil, actual_km: nil)
+    props = {
+      "Status" => {"select" => {"name" => status}},
+      "Type" => {"select" => {"name" => type}},
+      "Planned Distance (km)" => {"number" => planned_km},
+      "Actual Distance (km)" => {"number" => actual_km}
+    }
+    {"id" => "workout-#{SecureRandom.hex(4)}", "properties" => props}
+  end
+
+  def daily_log_row(red_flags: [])
+    flag_data = red_flags.map { |f| {"name" => f} }
+    {
+      "id" => "daily-#{SecureRandom.hex(4)}",
+      "properties" => {"Red Flags" => {"multi_select" => flag_data}}
+    }
+  end
+
+  def seed_metrics(date, hrv: nil, rhr: nil, sleep: nil, weight: nil)
+    tz = ActiveSupport::TimeZone["America/Los_Angeles"]
+    noon = tz.local(date.year, date.month, date.day, 12)
+    @user.health_metrics.create!(metric_name: "heart_rate_variability", value: hrv, units: "ms", recorded_at: noon) if hrv
+    @user.health_metrics.create!(metric_name: "resting_heart_rate", value: rhr, units: "bpm", recorded_at: noon) if rhr
+    @user.health_metrics.create!(metric_name: "sleep_analysis", value: sleep, units: "h", recorded_at: noon) if sleep
+    @user.health_metrics.create!(metric_name: "weight", value: weight, units: "kg", recorded_at: noon) if weight
+  end
+
+  # (a) creates row with computed aggregates + parsed LLM fields when none exists
+  test "creates row with computed aggregates and parsed LLM fields when none exists" do
+    seed_metrics(WEEK_START, hrv: 55.0, rhr: 48.0, sleep: 7.5, weight: 61.0)
+    seed_metrics(WEEK_START + 1, hrv: 60.0, rhr: 50.0, sleep: 8.0, weight: 61.2)
+
+    workouts_rows = [
+      workout_row(status: "Done", type: "Easy", planned_km: 5.0, actual_km: 5.1),
+      workout_row(status: "Done", type: "Long", planned_km: 12.0, actual_km: 11.8),
+      workout_row(status: "Planned", type: "Quality", planned_km: 8.0, actual_km: nil)
+    ]
+    daily_logs_rows = [daily_log_row(red_flags: ["RHR up"])]
+
+    # Query sequence: weekly-review query (empty), workouts query, daily-logs query
+    client = FakeNotionClient.new(query_results: [[], workouts_rows, daily_logs_rows])
+
+    stub_llm_chat(@fake_llm_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      assert result.created
+      assert_equal 3, client.queries.size
+      assert_equal 1, client.creates.size
+      assert_empty client.updates
+
+      props = client.creates.first[:properties]
+
+      # LLM parsed fields
+      assert_equal "On Track", props["Status"]["select"]["name"]
+      assert_equal "Good mileage.", props["What Worked"]["rich_text"].first["text"]["content"]
+      assert_equal "Nothing.", props["What Broke"]["rich_text"].first["text"]["content"]
+      assert_equal "Keep it up.", props["Adjustment for Next Week"]["rich_text"].first["text"]["content"]
+
+      # Aggregates
+      assert_in_delta 25.0, props["Planned km"]["number"], 0.01  # 5+12+8
+      assert_in_delta 16.9, props["Actual km"]["number"], 0.1    # 5.1+11.8 (done rows)
+      assert_in_delta 11.8, props["Long Run Distance (km)"]["number"], 0.01
+      refute props["Quality Session Done"]["checkbox"]  # Quality is Planned, not Done
+      refute props["Strength Done"]["checkbox"]
+
+      # DB aggregates
+      assert_in_delta 57.5, props["Avg HRV"]["number"], 0.5    # (55+60)/2
+      assert_in_delta 49.0, props["Avg RHR"]["number"], 0.5    # (48+50)/2
+      assert_in_delta 7.75, props["Avg Sleep Hours"]["number"], 0.1
+      assert_in_delta 61.0, props["Weight Start (kg)"]["number"], 0.01
+      assert_in_delta 61.2, props["Weight End (kg)"]["number"], 0.01
+
+      # Red flags
+      flag_names = props["Red Flags Triggered"]["multi_select"].map { |f| f["name"] }
+      assert_includes flag_names, "RHR up"
+
+      # Create-only properties
+      assert_match(/W6/, props["Week"]["title"].first["text"]["content"])
+      assert_equal 6, props["Week Number"]["number"]
+      assert_equal WEEK_START.iso8601, props["Week Start"]["date"]["start"]
+    end
+  end
+
+  # (b) updates (not creates) when a row for Week Start exists
+  test "updates existing row and does not create a duplicate" do
+    existing = {
+      "id" => "weekly-existing-1",
+      "properties" => {
+        "Red Flags Triggered" => {"multi_select" => []}
+      }
+    }
+    workouts_rows = [workout_row(status: "Done", type: "Easy", planned_km: 5.0, actual_km: 5.0)]
+    daily_logs_rows = []
+
+    client = FakeNotionClient.new(query_results: [[existing], workouts_rows, daily_logs_rows])
+
+    stub_llm_chat(@fake_llm_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      refute result.created
+      assert_empty client.creates
+      assert_equal 1, client.updates.size
+      assert_equal "weekly-existing-1", client.updates.first[:page_id]
+
+      # Update should NOT include create-only properties
+      props = client.updates.first[:properties]
+      refute props.key?("Week")
+      refute props.key?("Week Number")
+      refute props.key?("Week Start")
+    end
+  end
+
+  # (c) red-flag mapping: "Sleep <6.5h" → "Sleep short" and "Multiple red flags" at ≥3
+  test "maps Sleep <6.5h to Sleep short and adds Multiple red flags at 3+ distinct flags" do
+    daily_logs_rows = [
+      daily_log_row(red_flags: ["Sleep <6.5h", "RHR up"]),
+      daily_log_row(red_flags: ["HRV down", "Weight loss too fast"])
+    ]
+
+    # 4 distinct mapped flags → Multiple red flags added
+    client = FakeNotionClient.new(query_results: [[], [], daily_logs_rows])
+
+    stub_llm_chat(@fake_llm_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      props = client.creates.first[:properties]
+      flag_names = props["Red Flags Triggered"]["multi_select"].map { |f| f["name"] }
+
+      assert_includes flag_names, "Sleep short"       # mapped from "Sleep <6.5h"
+      refute_includes flag_names, "Sleep <6.5h"       # original name dropped
+      assert_includes flag_names, "RHR up"
+      assert_includes flag_names, "HRV down"
+      assert_includes flag_names, "Weight loss too fast"
+      assert_includes flag_names, "Multiple red flags"
+    end
+  end
+
+  test "does not add Multiple red flags when fewer than 3 distinct flags" do
+    daily_logs_rows = [daily_log_row(red_flags: ["Sleep <6.5h", "RHR up"])]
+
+    client = FakeNotionClient.new(query_results: [[], [], daily_logs_rows])
+
+    stub_llm_chat(@fake_llm_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      props = client.creates.first[:properties]
+      flag_names = props["Red Flags Triggered"]["multi_select"].map { |f| f["name"] }
+
+      assert_includes flag_names, "Sleep short"
+      refute_includes flag_names, "Multiple red flags"
+    end
+  end
+
+  # (d) malformed LLM JSON → "Cautious" fallback, aggregates still written
+  test "malformed LLM JSON falls back to Cautious status with raw text in What Worked" do
+    raw_bad_response = Data.define(:content).new(content: "Sorry, I cannot do that right now.")
+
+    workouts_rows = [workout_row(status: "Done", type: "Easy", planned_km: 5.0, actual_km: 5.0)]
+    client = FakeNotionClient.new(query_results: [[], workouts_rows, []])
+
+    stub_llm_chat(raw_bad_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      props = client.creates.first[:properties]
+
+      assert_equal "Cautious", props["Status"]["select"]["name"]
+      what_worked_text = props["What Worked"]["rich_text"].first["text"]["content"]
+      assert_match "Sorry, I cannot do that right now.", what_worked_text
+
+      # Aggregates still written
+      assert props.key?("Actual km")
+      assert props.key?("Planned km")
+    end
+  end
+
+  # (e) Long Run Distance only considers Done+Long rows
+  test "Long Run Distance only considers Done rows with Type Long" do
+    workouts_rows = [
+      workout_row(status: "Done", type: "Long", planned_km: 12.0, actual_km: 15.0),
+      workout_row(status: "Planned", type: "Long", planned_km: 18.0, actual_km: 18.0), # Planned — must be ignored
+      workout_row(status: "Done", type: "Easy", planned_km: 5.0, actual_km: 5.0)        # Easy — must be ignored
+    ]
+
+    client = FakeNotionClient.new(query_results: [[], workouts_rows, []])
+
+    stub_llm_chat(@fake_llm_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      props = client.creates.first[:properties]
+      assert_in_delta 15.0, props["Long Run Distance (km)"]["number"], 0.01
+    end
+  end
+
+  test "omits nil aggregates from properties" do
+    # No health metrics → no HRV/RHR/sleep/weight aggregates
+    client = FakeNotionClient.new(query_results: [[], [], []])
+
+    stub_llm_chat(@fake_llm_response) do
+      Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+    end
+
+    props = client.creates.first[:properties]
+    refute props.key?("Avg HRV")
+    refute props.key?("Avg RHR")
+    refute props.key?("Avg Sleep Hours")
+    refute props.key?("Weight Start (kg)")
+    refute props.key?("Weight End (kg)")
+    refute props.key?("Planned km")
+    refute props.key?("Actual km")
+  end
+
+  test "returns failure result on client error" do
+    client = FakeNotionClient.new
+    def client.query_data_source(*) = raise(Notion::Client::Error, "API down")
+
+    result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+    refute result.success
+    assert_match "API down", result.error
+  end
+end

--- a/test/services/notion/weekly_review_generator_test.rb
+++ b/test/services/notion/weekly_review_generator_test.rb
@@ -197,6 +197,35 @@ class Notion::WeeklyReviewGeneratorTest < ActiveSupport::TestCase
     end
   end
 
+  # regression: threshold must be evaluated on the union of existing + new flags
+  test "adds Multiple red flags when existing row already has 2 flags and new logs contribute 2 more" do
+    existing = {
+      "id" => "weekly-existing-2",
+      "properties" => {
+        "Red Flags Triggered" => {"multi_select" => [{"name" => "Low mood"}, {"name" => "Sharp pain"}]}
+      }
+    }
+    daily_logs_rows = [
+      daily_log_row(red_flags: ["RHR up", "HRV down"])
+    ]
+
+    client = FakeNotionClient.new(query_results: [[existing], [], daily_logs_rows])
+
+    stub_llm_chat(@fake_llm_response) do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      assert result.success
+      props = client.updates.first[:properties]
+      flag_names = props["Red Flags Triggered"]["multi_select"].map { |f| f["name"] }
+
+      assert_includes flag_names, "Low mood"
+      assert_includes flag_names, "Sharp pain"
+      assert_includes flag_names, "RHR up"
+      assert_includes flag_names, "HRV down"
+      assert_includes flag_names, "Multiple red flags"
+    end
+  end
+
   # (d) malformed LLM JSON → "Cautious" fallback, aggregates still written
   test "malformed LLM JSON falls back to Cautious status with raw text in What Worked" do
     raw_bad_response = Data.define(:content).new(content: "Sorry, I cannot do that right now.")

--- a/test/services/notion/weekly_review_generator_test.rb
+++ b/test/services/notion/weekly_review_generator_test.rb
@@ -249,6 +249,20 @@ class Notion::WeeklyReviewGeneratorTest < ActiveSupport::TestCase
     end
   end
 
+  test "LLM transport error fails the run without writing anything" do
+    workouts_rows = [workout_row(status: "Done", type: "Easy", planned_km: 5.0, actual_km: 5.0)]
+    client = FakeNotionClient.new(query_results: [[], workouts_rows, []])
+
+    stub_llm_chat_error("API timeout") do
+      result = Notion::WeeklyReviewGenerator.call(@user, date: DATE, client: client)
+
+      refute result.success
+      assert_match "API timeout", result.error
+      assert_empty client.creates
+      assert_empty client.updates
+    end
+  end
+
   # (e) Long Run Distance only considers Done+Long rows
   test "Long Run Distance only considers Done rows with Type Long" do
     workouts_rows = [

--- a/test/services/notion/workout_commentary_generator_test.rb
+++ b/test/services/notion/workout_commentary_generator_test.rb
@@ -12,7 +12,7 @@ class Notion::WorkoutCommentaryGeneratorTest < ActiveSupport::TestCase
     ENV["NOTION_API_TOKEN"] = "test-token"
 
     @user = users(:one)
-    @plan = plans(:with_content)
+    @plan = plans(:with_content) # belongs to users(:one) via fixture; the generator reaches it through workout.user.plan
     @fake_response = Data.define(:content).new(content: "Good steady effort today.")
 
     @workout = @user.workouts.create!(

--- a/test/services/notion/workout_commentary_generator_test.rb
+++ b/test/services/notion/workout_commentary_generator_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+require_relative "fake_notion_client"
+require_relative "../../support/llm_stubbing"
+
+class Notion::WorkoutCommentaryGeneratorTest < ActiveSupport::TestCase
+  include LlmStubbing
+
+  setup do
+    @orig_llm_model = ENV["LLM_MODEL"]
+    @orig_notion_api_token = ENV["NOTION_API_TOKEN"]
+    ENV["LLM_MODEL"] = "gpt-5-nano"
+    ENV["NOTION_API_TOKEN"] = "test-token"
+
+    @user = users(:one)
+    @plan = plans(:with_content)
+    @fake_response = Data.define(:content).new(content: "Good steady effort today.")
+
+    @workout = @user.workouts.create!(
+      external_id: "commentary-test-#{SecureRandom.hex(4)}",
+      workout_type: "Running",
+      started_at: 1.day.ago,
+      ended_at: 1.day.ago + 35.minutes,
+      duration: 2100,
+      distance: 5.0,
+      distance_units: "km",
+      energy_burned: 410,
+      notion_page_id: "notion-page-abc",
+      metadata: {"heartRate" => {"avg" => 152.3}}
+    )
+  end
+
+  teardown do
+    ENV["LLM_MODEL"] = @orig_llm_model
+    ENV["NOTION_API_TOKEN"] = @orig_notion_api_token
+  end
+
+  test "success path appends one paragraph block containing LLM text to workout notion_page_id" do
+    client = FakeNotionClient.new
+
+    stub_llm_chat(@fake_response) do
+      result = Notion::WorkoutCommentaryGenerator.call(@workout, client: client)
+
+      assert result.success
+      assert_equal "Good steady effort today.", result.commentary
+      assert_equal 1, client.appends.size
+      append = client.appends.first
+      assert_equal "notion-page-abc", append[:page_id]
+      block = append[:children].first
+      assert_equal "paragraph", block["type"]
+      assert_includes block.dig("paragraph", "rich_text", 0, "text", "content"), "Good steady effort today."
+      assert_includes block.dig("paragraph", "rich_text", 0, "text", "content"), "🤖 Coach:"
+    end
+  end
+
+  test "prompt includes workout type, distance, and plan content" do
+    client = FakeNotionClient.new
+    captured_prompt = nil
+
+    stub_llm_chat(@fake_response, capture: ->(prompt) { captured_prompt = prompt }) do
+      Notion::WorkoutCommentaryGenerator.call(@workout, client: client)
+    end
+
+    assert_includes captured_prompt, "Running"
+    assert_includes captured_prompt, "5.0"
+    assert_includes captured_prompt, @plan.content
+  end
+
+  test "LLM failure returns Result success false and makes no append_blocks call" do
+    client = FakeNotionClient.new
+
+    stub_llm_chat_error("LLM timeout") do
+      result = Notion::WorkoutCommentaryGenerator.call(@workout, client: client)
+
+      refute result.success
+      assert_equal "LLM timeout", result.error
+      assert_empty client.appends
+    end
+  end
+
+  test "workout without notion_page_id returns failure with no API call and no LLM call" do
+    @workout.update_column(:notion_page_id, nil)
+    client = FakeNotionClient.new
+    llm_called = false
+
+    original_chat = RubyLLM.method(:chat)
+    RubyLLM.define_singleton_method(:chat) { |**_|
+      llm_called = true
+      raise "should not be called"
+    }
+
+    result = Notion::WorkoutCommentaryGenerator.call(@workout, client: client)
+
+    refute result.success
+    assert_match(/notion_page_id/, result.error)
+    assert_empty client.appends
+    refute llm_called
+  ensure
+    RubyLLM.define_singleton_method(:chat, original_chat)
+  end
+end

--- a/test/services/notion/workout_sync_test.rb
+++ b/test/services/notion/workout_sync_test.rb
@@ -56,6 +56,73 @@ class Notion::WorkoutSyncTest < ActiveSupport::TestCase
     refute props.key?("Notes")
   end
 
+  # Issue 1 / test (a): "Outdoor Run" matches a Planned Easy row
+  test "Outdoor Run matches a planned Easy row" do
+    workout = create_run(workout_type: "Outdoor Run")
+    client = FakeNotionClient.new(query_results: [[planned_row]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    assert_equal [workout.id], result.newly_synced_workout_ids
+    assert_equal "Easy Run", result.day_type
+    assert_equal "plan-1", workout.reload.notion_page_id
+    assert_equal "Done", client.updates.first[:properties]["Status"]["select"]["name"]
+  end
+
+  # Issue 2 / test (b): "Outdoor Walk" with no candidates → skip entirely
+  test "Outdoor Walk with no candidates is skipped entirely" do
+    workout = create_run(workout_type: "Outdoor Walk", distance: nil, distance_units: nil, metadata: {})
+    client = FakeNotionClient.new(query_results: [[]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    assert_empty client.creates
+    assert_empty client.updates
+    assert_empty result.newly_synced_workout_ids
+    assert_nil result.day_type
+    assert_nil workout.reload.notion_page_id
+  end
+
+  # Issue 2 / test (c): "Pool Swim" creates an unplanned row with Type "Cross"
+  test "Pool Swim creates unplanned row with Type Cross" do
+    workout = create_run(workout_type: "Pool Swim", distance: 1.5, distance_units: "km", metadata: {})
+    client = FakeNotionClient.new(query_results: [[]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    assert_equal 1, client.creates.size
+    assert_empty client.updates
+    props = client.creates.first[:properties]
+    assert_equal "Cross", props["Type"]["select"]["name"]
+    assert_equal "Done", props["Status"]["select"]["name"]
+    assert_equal "created-1", workout.reload.notion_page_id
+    assert_equal [workout.id], result.newly_synced_workout_ids
+  end
+
+  # Issue 3 / test (d): adopt a Done row — actuals only, no Status write, empty newly_synced
+  test "adopts a Done candidate: updates actuals only, persists page id, empty newly_synced, correct day_type" do
+    workout = create_run
+    done_row = planned_row(id: "done-1", type: "Easy", status: "Done")
+    client = FakeNotionClient.new(query_results: [[done_row]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    assert_empty result.newly_synced_workout_ids
+    assert_equal "Easy Run", result.day_type
+    assert_equal "done-1", workout.reload.notion_page_id
+
+    assert_equal 1, client.updates.size
+    props = client.updates.first[:properties]
+    assert_equal "done-1", client.updates.first[:page_id]
+    refute props.key?("Status"), "Should NOT write Status when adopting a Done row"
+    assert props.key?("Actual Duration (min)")
+  end
+
+  # Issue 3 / test (e): Skipped rows are not adopted — Golf falls through to unplanned create
   test "ignores Skipped and Done rows as candidates and creates unplanned row" do
     workout = create_run(workout_type: "Golf", distance: nil, distance_units: nil, metadata: {})
     client = FakeNotionClient.new(query_results: [[planned_row(status: "Skipped", type: "Golf")]])

--- a/test/services/notion/workout_sync_test.rb
+++ b/test/services/notion/workout_sync_test.rb
@@ -111,4 +111,16 @@ class Notion::WorkoutSyncTest < ActiveSupport::TestCase
     assert_nil result.day_type
     assert_empty result.newly_synced_workout_ids
   end
+
+  test "pace rounds correctly when seconds-per-km crosses minute boundary" do
+    # 2098 seconds / 5.0 km = 419.6 s/km → rounds to 420 → 7:00/km
+    create_run(duration: 2098)
+    client = FakeNotionClient.new(query_results: [[planned_row]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    props = client.updates.first[:properties]
+    assert_equal "7:00/km", props["Actual Avg Pace"]["rich_text"].first["text"]["content"]
+  end
 end

--- a/test/services/notion/workout_sync_test.rb
+++ b/test/services/notion/workout_sync_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+require_relative "fake_notion_client"
+
+class Notion::WorkoutSyncTest < ActiveSupport::TestCase
+  DATE = Date.new(2026, 6, 11)
+
+  setup do
+    @user = users(:one)
+    @orig_week1_start = ENV["TRAINING_WEEK1_START"]
+    @orig_workouts_ds_id = ENV["NOTION_WORKOUTS_DS_ID"]
+    ENV["TRAINING_WEEK1_START"] = "2026-05-04"
+    ENV["NOTION_WORKOUTS_DS_ID"] = "ds-workouts"
+    @started = ActiveSupport::TimeZone["America/Los_Angeles"].local(2026, 6, 11, 7)
+  end
+
+  teardown do
+    ENV["TRAINING_WEEK1_START"] = @orig_week1_start
+    ENV["NOTION_WORKOUTS_DS_ID"] = @orig_workouts_ds_id
+  end
+
+  def create_run(attrs = {})
+    @user.workouts.create!({
+      external_id: SecureRandom.uuid, workout_type: "Running",
+      started_at: @started, ended_at: @started + 35.minutes, duration: 2100,
+      distance: 5.0, distance_units: "km", energy_burned: 410.4,
+      metadata: {"heartRate" => {"avg" => 152.3, "min" => 110, "max" => 171}}
+    }.merge(attrs))
+  end
+
+  def planned_row(id: "plan-1", type: "Easy", status: "Planned")
+    {"id" => id, "properties" => {
+      "Type" => {"select" => {"name" => type}},
+      "Status" => {"select" => {"name" => status}}
+    }}
+  end
+
+  test "matches a planned run, fills actuals, sets Done, stores page id" do
+    workout = create_run
+    client = FakeNotionClient.new(query_results: [[planned_row]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert result.success
+    assert_equal [workout.id], result.newly_synced_workout_ids
+    assert_equal "Easy Run", result.day_type
+    assert_equal "plan-1", workout.reload.notion_page_id
+
+    props = client.updates.first[:properties]
+    assert_equal 5.0, props["Actual Distance (km)"]["number"]
+    assert_equal 35.0, props["Actual Duration (min)"]["number"]
+    assert_equal 152.0, props["Actual Avg HR"]["number"]
+    assert_equal "7:00/km", props["Actual Avg Pace"]["rich_text"].first["text"]["content"]
+    assert_equal 410.0, props["kCal Burned"]["number"]
+    assert_equal "Done", props["Status"]["select"]["name"]
+    refute props.key?("Felt")
+    refute props.key?("Notes")
+  end
+
+  test "ignores Skipped and Done rows as candidates and creates unplanned row" do
+    workout = create_run(workout_type: "Golf", distance: nil, distance_units: nil, metadata: {})
+    client = FakeNotionClient.new(query_results: [[planned_row(status: "Skipped", type: "Golf")]])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_empty client.updates
+    create = client.creates.first
+    props = create[:properties]
+    assert_equal "W6 Thu - Golf (unplanned)", props["Session"]["title"].first["text"]["content"]
+    assert_equal "Golf", props["Type"]["select"]["name"]
+    assert_equal "Done", props["Status"]["select"]["name"]
+    assert_equal 6.0, props["Week"]["number"]
+    assert_equal "created-1", workout.reload.notion_page_id
+    assert_equal "Golf", result.day_type
+  end
+
+  test "already-linked workout updates its page without re-matching or re-announcing" do
+    create_run(notion_page_id: "page-9")
+    client = FakeNotionClient.new
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_empty client.queries          # no matching query needed
+    assert_equal "page-9", client.updates.first[:page_id]
+    refute client.updates.first[:properties].key?("Status")
+    assert_empty result.newly_synced_workout_ids
+  end
+
+  test "converts miles to km" do
+    create_run(distance: 3.1, distance_units: "mi")
+    client = FakeNotionClient.new(query_results: [[planned_row]])
+
+    Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_in_delta 4.99, client.updates.first[:properties]["Actual Distance (km)"]["number"], 0.01
+  end
+
+  test "long run outranks easy for day_type" do
+    create_run
+    create_run(started_at: @started + 8.hours, ended_at: @started + 9.hours)
+    client = FakeNotionClient.new(query_results: [[planned_row(id: "p1", type: "Easy"), planned_row(id: "p2", type: "Long")], []])
+
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+
+    assert_equal "Long Run", result.day_type
+  end
+
+  test "no workouts returns nil day_type and success" do
+    client = FakeNotionClient.new
+    result = Notion::WorkoutSync.call(@user, date: DATE, client: client)
+    assert result.success
+    assert_nil result.day_type
+    assert_empty result.newly_synced_workout_ids
+  end
+end

--- a/test/services/plan_suggestion_generator_test.rb
+++ b/test/services/plan_suggestion_generator_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require_relative "../support/llm_stubbing"
 
 class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
+  include LlmStubbing
+
   setup do
     @plan = plans(:with_content)
     @fake_response = Data.define(:content).new(content: "Go for a 5K easy run today.")
@@ -146,31 +149,5 @@ class PlanSuggestionGeneratorTest < ActiveSupport::TestCase
     end
 
     assert_includes captured_prompt, "No workouts completed yet today"
-  end
-
-  private
-
-  def stub_llm_chat(response, capture: nil, &block)
-    fake_chat = Object.new
-    fake_chat.define_singleton_method(:with_params) { |**_| self }
-    fake_chat.define_singleton_method(:with_instructions) { |_| self }
-    fake_chat.define_singleton_method(:ask) { |prompt|
-      capture&.call(prompt)
-      response
-    }
-
-    original_chat = RubyLLM.method(:chat)
-    RubyLLM.define_singleton_method(:chat) { |**_| fake_chat }
-    yield
-  ensure
-    RubyLLM.define_singleton_method(:chat, original_chat)
-  end
-
-  def stub_llm_chat_error(message, &block)
-    original_chat = RubyLLM.method(:chat)
-    RubyLLM.define_singleton_method(:chat) { |**_| raise message }
-    yield
-  ensure
-    RubyLLM.define_singleton_method(:chat, original_chat)
   end
 end

--- a/test/support/llm_stubbing.rb
+++ b/test/support/llm_stubbing.rb
@@ -1,0 +1,25 @@
+module LlmStubbing
+  def stub_llm_chat(response, capture: nil, &block)
+    fake_chat = Object.new
+    fake_chat.define_singleton_method(:with_params) { |**_| self }
+    fake_chat.define_singleton_method(:with_instructions) { |_| self }
+    fake_chat.define_singleton_method(:ask) { |prompt|
+      capture&.call(prompt)
+      response
+    }
+
+    original_chat = RubyLLM.method(:chat)
+    RubyLLM.define_singleton_method(:chat) { |**_| fake_chat }
+    yield
+  ensure
+    RubyLLM.define_singleton_method(:chat, original_chat)
+  end
+
+  def stub_llm_chat_error(message, &block)
+    original_chat = RubyLLM.method(:chat)
+    RubyLLM.define_singleton_method(:chat) { |**_| raise message }
+    yield
+  ensure
+    RubyLLM.define_singleton_method(:chat, original_chat)
+  end
+end

--- a/test/support/llm_stubbing.rb
+++ b/test/support/llm_stubbing.rb
@@ -1,5 +1,5 @@
 module LlmStubbing
-  def stub_llm_chat(response, capture: nil, &block)
+  def stub_llm_chat(response, capture: nil)
     fake_chat = Object.new
     fake_chat.define_singleton_method(:with_params) { |**_| self }
     fake_chat.define_singleton_method(:with_instructions) { |_| self }
@@ -15,7 +15,7 @@ module LlmStubbing
     RubyLLM.define_singleton_method(:chat, original_chat)
   end
 
-  def stub_llm_chat_error(message, &block)
+  def stub_llm_chat_error(message)
     original_chat = RubyLLM.method(:chat)
     RubyLLM.define_singleton_method(:chat) { |**_| raise message }
     yield


### PR DESCRIPTION
## Summary
- Syncs Apple Health data from the Signals DB to the three Notion training databases (Daily Logs, Workouts, Weekly Reviews) automatically — webhook-chained `NotionSyncJob` plus a 30-min `notion_catchup` recurring task
- Workouts are match-and-filled onto pre-seeded Runna plan rows (date + type matching, `Done`-row adoption for idempotency, walks/hikes skipped); daily logs upsert by date with strict automation/human field ownership
- LLM commentary via ruby_llm: per-workout coach notes appended to the page body, end-of-day narrative + auto-detected red flags (merge-only) into Daily Logs `Notes`, and Sunday weekly reviews upserted by `Week Start` (both evening jobs ship commented out in `config/recurring.yml`, to be enabled after a clean day)

Spec: `docs/superpowers/specs/2026-06-12-notion-training-sync-design.md` · Plan: `docs/superpowers/plans/2026-06-12-notion-training-sync.md`

## Verification done
- 240 tests green, standardrb + brakeman clean
- Live end-to-end run against real Notion: today's run matched onto "W6 Fri - 6km Easy Run" with actuals + commentary; daily log populated with narrative + `Sleep <6.5h` red flag; "Week 6" review row updated in place (double-run confirmed no duplicates)

## Before merging/deploying
- [ ] Render env vars set: `NOTION_API_TOKEN` (note: local .env had it named `NOTION_API_KEY` — the code reads `NOTION_API_TOKEN`), `NOTION_DAILY_LOGS_DS_ID`, `NOTION_WORKOUTS_DS_ID`, `NOTION_WEEKLY_REVIEWS_DS_ID`, `TRAINING_WEEK1_START=2026-05-04`
- [ ] After one clean day: uncomment `daily_log_commentary` and `weekly_review` in `config/recurring.yml`
- [ ] Check `solid_queue_failed_executions` after the first evening run

🤖 Generated with [Claude Code](https://claude.com/claude-code)